### PR TITLE
use env variable to allow customize config/data/runtime directory paths

### DIFF
--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -56,7 +56,11 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 		return nil, err
 	}
 
-	rtDir = filepath.Join(rtDir, "podman")
+	// The runtime directory can be customized using the PODMAN_RUNTIME_DIR env variable
+	// Its default value will be podman
+	// When used by macadam it can be customized to use a different path like macadam
+	runtimeDir := GetRuntimeDirSuffix()
+	rtDir = filepath.Join(rtDir, runtimeDir)
 	configDir, err := GetConfDir(vmType)
 	if err != nil {
 		return nil, err
@@ -109,12 +113,16 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 }
 
 // DataDirPrefix returns the path prefix for all machine data files
+// The config directory can be customized using the PODMAN_DATA_DIR env variable
+// Its default value will be /podman/machine
+// When used by macadam it can be customized to use a different path like /macadam/machine
 func DataDirPrefix() (string, error) {
 	data, err := homedir.GetDataHome()
 	if err != nil {
 		return "", err
 	}
-	dataDir := filepath.Join(data, "containers", "podman", "machine")
+	machineDataDir := getDataDirSuffix()
+	dataDir := filepath.Join(data, "containers", machineDataDir)
 	return dataDir, nil
 }
 
@@ -134,12 +142,16 @@ func GetConfDir(vmType define.VMType) (string, error) {
 }
 
 // ConfDirPrefix returns the path prefix for all machine config files
+// The config directory can be customized using the PODMAN_DATA_DIR env variable
+// Its default value will be /podman/machine
+// When used by macadam it can be customized to use a different path like /macadam/machine
 func ConfDirPrefix() (string, error) {
 	conf, err := homedir.GetConfigHome()
 	if err != nil {
 		return "", err
 	}
-	confDir := filepath.Join(conf, "containers", "podman", "machine")
+	machineDataDir := getDataDirSuffix()
+	confDir := filepath.Join(conf, "containers", machineDataDir)
 	return confDir, nil
 }
 
@@ -157,4 +169,20 @@ func WithPodmanPrefix(name string) string {
 		name = "podman-" + name
 	}
 	return name
+}
+
+func getDataDirSuffix() string {
+	machineDir := os.Getenv("PODMAN_DATA_DIR")
+	if machineDir == "" {
+		machineDir = filepath.Join("podman", "machine")
+	}
+	return machineDir
+}
+
+func GetRuntimeDirSuffix() string {
+	runtimeDir := os.Getenv("PODMAN_RUNTIME_DIR")
+	if runtimeDir == "" {
+		runtimeDir = filepath.Join("podman")
+	}
+	return runtimeDir
 }

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/storage/pkg/homedir"
 )
 
@@ -35,7 +36,8 @@ func GetRootlessRuntimeDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	runtimeDir := filepath.Join(data, "containers", "podman")
+	rtDir := env.GetRuntimeDir()
+	runtimeDir := filepath.Join(data, "containers", rtDir)
 	return runtimeDir, nil
 }
 


### PR DESCRIPTION
based on what is the caller the code should behave differently, and so we should allow to define a specific path for the config/data/runtime directories. This way, when launching podman and macadam, we can separate their context and they can work separately without misbehavior.

It is related to https://github.com/cfergeau/macadam/issues/44