### PR TITLE
fix func name

### DIFF
--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -36,7 +36,7 @@ func GetRootlessRuntimeDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rtDir := env.GetRuntimeDir()
+	rtDir := env.GetRuntimeDirSuffix()
 	runtimeDir := filepath.Join(data, "containers", rtDir)
 	return runtimeDir, nil
 }


### PR DESCRIPTION
During the refactoring of utils_windows.go in https://github.com/cfergeau/podman/pull/1 i missed to update the name of the func. This patch fixes the wrong name.