### PR TITLE
support cloud init on macOS

### DIFF
--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -1,0 +1,40 @@
+package cloudinit
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type User struct {
+	Name    string   `yaml:"name"`
+	Sudo    string   `yaml:"sudo"`
+	Shell   string   `yaml:"shell"`
+	Groups  string   `yaml:"groups"`
+	SSHKeys []string `yaml:"ssh_authorized_keys"`
+}
+
+type UserData struct {
+	Users []User `yaml:"users"`
+}
+
+func GenerateUserData(dir string, data UserData) (string, error) {
+	yamlBytes, err := yaml.Marshal(&data)
+	if err != nil {
+		logrus.Errorf("Error marshaling to YAML: %v", err)
+		return "", err
+	}
+
+	headerLine := "#cloud-config\n"
+	yamlBytes = append([]byte(headerLine), yamlBytes...)
+
+	path := filepath.Join(dir, "user-data")
+	err = os.WriteFile(path, yamlBytes, 0644)
+	if err != nil {
+		logrus.Errorf("Error creating temp file: %v", err)
+		return "", err
+	}
+	return path, nil
+}

--- a/pkg/machine/define/initopts.go
+++ b/pkg/machine/define/initopts.go
@@ -21,4 +21,5 @@ type InitOptions struct {
 	UserModeNetworking *bool  // nil = use backend/system default, false = disable, true = enable
 	USBs               []string
 	ImagePuller        ImagePuller
+	CloudInit          bool
 }

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -53,6 +53,8 @@ type MachineConfig struct {
 	Starting bool
 
 	Rosetta bool
+
+	CloudInit bool
 }
 
 type machineImage interface { //nolint:unused

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -96,6 +96,7 @@ func NewMachineConfig(opts define.InitOptions, dirs *define.MachineDirs, sshIden
 	mc.Created = time.Now()
 
 	mc.HostUser = HostUser{UID: getHostUID(), Rootful: opts.Rootful}
+	mc.CloudInit = opts.CloudInit
 
 	return mc, nil
 }


### PR DESCRIPTION
when using a RHEL VM cloud-init is preferred over ignition for customizing the VM. With https://github.com/crc-org/vfkit/issues/208 vfkit will be able to accept raw config files to enable cloud-init.

This patch adds the logic to create a user-data config file to register users + their ssh key by leveraging cloud-init
