### PR TITLE
terminate gvproxy process

### DIFF
--- a/pkg/machine/gvproxy_unix.go
+++ b/pkg/machine/gvproxy_unix.go
@@ -64,7 +64,7 @@ func waitOnProcess(processID int) error {
 		return nil
 	}
 
-	if err := p.Kill(); err != nil {
+	if err := p.Terminate(); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
 			logrus.Debugf("Gvproxy already dead, exiting cleanly")
 			return nil


### PR DESCRIPTION
in the current implementation gvproxy gets killed (SIGKILL), however this does not allow gvproxy to dispose its resources. This patch uses the Terminate func to send a SIGTERM to gvproxy so that it can gracefully stop and deletes its resources. This would prevent the caller from being responsible of the clean and prevent some annoying issues.

A problem caused by a socket not being disposed is https://github.com/crc-org/macadam/issues/86
