### PR TITLE
allow to customize tool prefix for wsl dist

### DIFF
--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -2,14 +2,24 @@ package env
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/homedir"
 )
+
+var getToolName = sync.OnceValue(func() string {
+	toolName := os.Getenv("PODMAN_TOOL_PREFIX")
+	if toolName == "" {
+		toolName = "podman"
+	}
+	return toolName
+})
 
 // GetCacheDir returns the dir where VM images are downloaded into when pulled
 func GetCacheDir(vmType define.VMType) (string, error) {
@@ -164,9 +174,10 @@ func GetSSHIdentityPath(name string) (string, error) {
 	return filepath.Join(datadir, name), nil
 }
 
-func WithPodmanPrefix(name string) string {
-	if !strings.HasPrefix(name, "podman") {
-		name = "podman-" + name
+func WithToolPrefix(name string) string {
+	toolName := getToolName()
+	if !strings.HasPrefix(name, toolName) {
+		name = fmt.Sprintf("%s-%s", toolName, name)
 	}
 	return name
 }

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -126,7 +126,7 @@ func LaunchWinProxy(opts WinProxyOpts, noInfo bool) {
 }
 
 func launchWinProxy(opts WinProxyOpts) (bool, string, error) {
-	machinePipe := env.WithPodmanPrefix(opts.Name)
+	machinePipe := env.WithToolPrefix(opts.Name)
 	if !PipeNameAvailable(machinePipe, MachineNameWait) {
 		return false, "", fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}

--- a/pkg/machine/shim/networking_windows.go
+++ b/pkg/machine/shim/networking_windows.go
@@ -11,7 +11,7 @@ import (
 )
 
 func setupMachineSockets(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) ([]string, string, machine.APIForwardingState, error) {
-	machinePipe := env.WithPodmanPrefix(mc.Name)
+	machinePipe := env.WithToolPrefix(mc.Name)
 	if !machine.PipeNameAvailable(machinePipe, machine.MachineNameWait) {
 		return nil, "", 0, fmt.Errorf("could not start api proxy since expected pipe is not available: %s", machinePipe)
 	}

--- a/pkg/machine/vmconfigs/machine_windows.go
+++ b/pkg/machine/vmconfigs/machine_windows.go
@@ -6,6 +6,6 @@ import (
 )
 
 func getPipe(name string) *define.VMFile {
-	pipeName := env.WithPodmanPrefix(name)
+	pipeName := env.WithToolPrefix(name)
 	return &define.VMFile{Path: `\\.\pipe\` + pipeName}
 }

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -61,7 +61,7 @@ func getConfigPathExt(name string, extension string) (string, error) {
 // TODO like provisionWSL, i think this needs to be pushed to use common
 // paths and types where possible
 func unprovisionWSL(mc *vmconfigs.MachineConfig) error {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 	if err := terminateDist(dist); err != nil {
 		logrus.Error(err)
 	}
@@ -93,7 +93,7 @@ func provisionWSLDist(name string, imagePath string, prompt string) (string, err
 		return "", fmt.Errorf("could not create wsldist directory: %w", err)
 	}
 
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	fmt.Println(prompt)
 	if err = runCmdPassThrough(wutil.FindWSL(), "--import", dist, distTarget, imagePath, "--version", "2"); err != nil {
 		return "", fmt.Errorf("the WSL import of guest OS failed: %w", err)
@@ -726,7 +726,7 @@ func unregisterDist(dist string) error {
 }
 
 func isRunning(name string) (bool, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	wsl, err := isWSLRunning(dist)
 	if err != nil {
 		return false, err
@@ -761,7 +761,7 @@ func getDiskSize(name string) strongunits.GiB {
 
 //nolint:unused
 func getCPUs(name string) (uint64, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}
@@ -791,7 +791,7 @@ func getCPUs(name string) (uint64, error) {
 
 //nolint:unused
 func getMem(name string) (strongunits.MiB, error) {
-	dist := env.WithPodmanPrefix(name)
+	dist := env.WithToolPrefix(name)
 	if run, _ := isWSLRunning(dist); !run {
 		return 0, nil
 	}

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -89,7 +89,7 @@ func (w WSLStubber) PrepareIgnition(_ *vmconfigs.MachineConfig, _ *ignition.Igni
 }
 
 func (w WSLStubber) Exists(name string) (bool, error) {
-	return isWSLExist(env.WithPodmanPrefix(name))
+	return isWSLExist(env.WithToolPrefix(name))
 }
 
 func (w WSLStubber) MountType() vmconfigs.VolumeMountType {
@@ -105,7 +105,7 @@ func (w WSLStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error,
 	// below if we wanted to hard error on the wsl unregister
 	// of the vm
 	wslRemoveFunc := func() error {
-		if err := runCmdPassThrough(wutil.FindWSL(), "--unregister", env.WithPodmanPrefix(mc.Name)); err != nil {
+		if err := runCmdPassThrough(wutil.FindWSL(), "--unregister", env.WithToolPrefix(mc.Name)); err != nil {
 			return err
 		}
 		return nil
@@ -154,7 +154,7 @@ func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.Se
 			return errors.New("user-mode networking can only be changed when the machine is not running")
 		}
 
-		dist := env.WithPodmanPrefix(mc.Name)
+		dist := env.WithToolPrefix(mc.Name)
 		if err := changeDistUserModeNetworking(dist, mc.SSH.RemoteUsername, mc.ImagePath.GetPath(), *opts.UserModeNetworking); err != nil {
 			return fmt.Errorf("failure changing state of user-mode networking setting: %w", err)
 		}
@@ -205,7 +205,7 @@ func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool
 }
 
 func (w WSLStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func() error, error) {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	err := wslInvoke(dist, "/root/bootstrap")
 	if err != nil {
@@ -239,7 +239,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		return err
 	}
 
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	// Stop user-mode networking if enabled
 	if err := stopUserModeNetworking(mc); err != nil {
@@ -277,7 +277,7 @@ func (w WSLStubber) StopHostNetworking(mc *vmconfigs.MachineConfig, vmType defin
 }
 
 func (w WSLStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error {
-	dist := env.WithPodmanPrefix(mc.Name)
+	dist := env.WithToolPrefix(mc.Name)
 
 	if err := wslInvoke(dist, "sh", "-c", fmt.Sprintf(changePort, port)); err != nil {
 		return fmt.Errorf("could not change SSH port for guest OS: %w", err)

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -104,7 +104,7 @@ func startUserModeNetworking(mc *vmconfigs.MachineConfig) error {
 		}
 	}
 
-	if err := createUserModeResolvConf(env.WithPodmanPrefix(mc.Name)); err != nil {
+	if err := createUserModeResolvConf(env.WithToolPrefix(mc.Name)); err != nil {
 		return err
 	}
 
@@ -274,7 +274,7 @@ func addUserModeNetEntry(mc *vmconfigs.MachineConfig) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, env.WithPodmanPrefix(mc.Name))
+	path := filepath.Join(entriesDir, env.WithToolPrefix(mc.Name))
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("could not add user-mode networking registration: %w", err)
@@ -289,7 +289,7 @@ func removeUserModeNetEntry(name string) error {
 		return err
 	}
 
-	path := filepath.Join(entriesDir, env.WithPodmanPrefix(name))
+	path := filepath.Join(entriesDir, env.WithToolPrefix(name))
 	return os.Remove(path)
 }
 


### PR DESCRIPTION
every time we create a new VM using macadam on WSL it gets prepend the string "podman". However, this could cause some error if users try to create two machine with the same name using both podman and macadam.

This patch allows to customize the prefix, so in macadam (and any other tool that uses podman in the backend) we can easily prevent an overlapping in dist name by adding a different prefix.