### PR TITLE
changes for wsl - in progress

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -28,7 +28,6 @@ const appendPort = `grep -q Port\ %d /etc/ssh/sshd_config || echo Port %d >> /et
 const changePort = `sed -E -i 's/^Port[[:space:]]+[0-9]+/Port %d/' /etc/ssh/sshd_config`
 
 const configServices = `ln -fs /usr/lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service
-ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.wants/podman.socket
 rm -f /etc/systemd/system/getty.target.wants/console-getty.service
 rm -f /etc/systemd/system/getty.target.wants/getty@tty1.service
 rm -f /etc/systemd/system/multi-user.target.wants/systemd-resolved.service
@@ -43,10 +42,16 @@ mkdir -p /home/[USER]/.config/systemd/[USER]/
 chown [USER]:[USER] /home/[USER]/.config
 `
 
+const configServicesPodman = `ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.wants/podman.socket` + configServices
+
 const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `
 
 const bootstrap = `#!/bin/bash
+nohup bash -c 'while true; do sleep 60; done' >/dev/null 2>&1 &
+`
+
+const bootstrapPodman = `#!/bin/bash
 ps -ef | grep -v grep | grep -q systemd && exit 0
 nohup unshare --kill-child --fork --pid --mount --mount-proc --propagation shared /lib/systemd/systemd >/dev/null 2>&1 &
 sleep 0.1
@@ -59,7 +64,9 @@ or type exit. This also means to log out you need to exit twice.
 
 `
 
-const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
+const sysdpidPodman = "SYSDPID=`ps -eo cmd,pid | grep -m 1 '^/lib/systemd/systemd' | awk '{print $2}'`"
+
+const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 'systemd' | awk '{print $2}'`"
 
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then
@@ -91,6 +98,10 @@ fi
 
 const wslConf = `[user]
 default=[USER]
+`
+
+const wslSystemdConf = `[boot]
+systemd=true
 `
 
 const wslConfUserNet = `

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -173,38 +173,40 @@ func configureSystem(mc *vmconfigs.MachineConfig, dist string, ansibleConfig *vm
 		}
 	}
 
-	lingerCmd := withUser("cat > /home/[USER]/.config/systemd/[USER]/linger-example.service", user)
-	if err := wslPipe(lingerService, dist, "sh", "-c", lingerCmd); err != nil {
-		return fmt.Errorf("could not generate linger service for guest OS: %w", err)
-	}
+	/*
+		lingerCmd := withUser("cat > /home/[USER]/.config/systemd/[USER]/linger-example.service", user)
+		if err := wslPipe(lingerService, dist, "sh", "-c", lingerCmd); err != nil {
+			return fmt.Errorf("could not generate linger service for guest OS: %w", err)
+		}
 
-	if err := enableUserLinger(mc, dist); err != nil {
-		return err
-	}
+		if err := enableUserLinger(mc, dist); err != nil {
+			return err
+		}
 
-	if err := wslPipe(withUser(lingerSetup, user), dist, "sh"); err != nil {
-		return fmt.Errorf("could not configure systemd settings for guest OS: %w", err)
-	}
+		if err := wslPipe(withUser(lingerSetup, user), dist, "sh"); err != nil {
+			return fmt.Errorf("could not configure systemd settings for guest OS: %w", err)
+		}
 
-	if err := wslPipe(containersConf, dist, "sh", "-c", "cat > /etc/containers/containers.conf"); err != nil {
-		return fmt.Errorf("could not create containers.conf for guest OS: %w", err)
-	}
+		if err := wslPipe(containersConf, dist, "sh", "-c", "cat > /etc/containers/containers.conf"); err != nil {
+			return fmt.Errorf("could not create containers.conf for guest OS: %w", err)
+		}
 
-	if err := configureRegistries(dist); err != nil {
-		return err
-	}
+		if err := configureRegistries(dist); err != nil {
+			return err
+		}
 
-	if err := setupPodmanDockerSock(dist, mc.HostUser.Rootful); err != nil {
-		return err
-	}
+		if err := setupPodmanDockerSock(dist, mc.HostUser.Rootful); err != nil {
+			return err
+		}
 
-	if err := wslInvoke(dist, "sh", "-c", "echo wsl > /etc/containers/podman-machine"); err != nil {
-		return fmt.Errorf("could not create podman-machine file for guest OS: %w", err)
-	}
+		if err := wslInvoke(dist, "sh", "-c", "echo wsl > /etc/containers/podman-machine"); err != nil {
+			return fmt.Errorf("could not create podman-machine file for guest OS: %w", err)
+		}
 
-	if err := configureBindMounts(dist, user); err != nil {
-		return err
-	}
+		if err := configureBindMounts(dist, user); err != nil {
+			return err
+		}
+	*/
 
 	return changeDistUserModeNetworking(dist, user, mc.ImagePath.GetPath(), mc.WSLHypervisor.UserModeNetworking)
 }
@@ -280,19 +282,21 @@ func configureRegistries(dist string) error {
 }
 
 func installScripts(dist string) error {
-	if err := wslPipe(enterns, dist, "sh", "-c",
-		"cat > /usr/local/bin/enterns; chmod 755 /usr/local/bin/enterns"); err != nil {
-		return fmt.Errorf("could not create enterns script for guest OS: %w", err)
-	}
+	/*
+		if err := wslPipe(enterns, dist, "sh", "-c",
+			"cat > /usr/local/bin/enterns; chmod 755 /usr/local/bin/enterns"); err != nil {
+			return fmt.Errorf("could not create enterns script for guest OS: %w", err)
+		}
 
-	if err := wslPipe(profile, dist, "sh", "-c",
-		"cat > /etc/profile.d/enterns.sh"); err != nil {
-		return fmt.Errorf("could not create motd profile script for guest OS: %w", err)
-	}
+		if err := wslPipe(profile, dist, "sh", "-c",
+			"cat > /etc/profile.d/enterns.sh"); err != nil {
+			return fmt.Errorf("could not create motd profile script for guest OS: %w", err)
+		}
 
-	if err := wslPipe(wslmotd, dist, "sh", "-c", "cat > /etc/wslmotd"); err != nil {
-		return fmt.Errorf("could not create a WSL MOTD for guest OS: %w", err)
-	}
+		if err := wslPipe(wslmotd, dist, "sh", "-c", "cat > /etc/wslmotd"); err != nil {
+			return fmt.Errorf("could not create a WSL MOTD for guest OS: %w", err)
+		}
+	*/
 
 	if err := wslPipe(bootstrap, dist, "sh", "-c",
 		"cat > /root/bootstrap; chmod 755 /root/bootstrap"); err != nil {
@@ -679,7 +683,8 @@ func getAllWSLDistros(running bool) (map[string]struct{}, error) {
 
 func isSystemdRunning(dist string) (bool, error) {
 	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "sh")
-	cmd.Stdin = strings.NewReader(sysdpid + "\necho $SYSDPID\n")
+	//cmd.Stdin = strings.NewReader(sysdpid + "\necho $SYSDPID\n")
+	cmd.Stdin = strings.NewReader("ps -p 1 -o comm=")
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return false, err
@@ -693,10 +698,13 @@ func isSystemdRunning(dist string) (bool, error) {
 	result := false
 	if scanner.Scan() {
 		text := scanner.Text()
-		i, err := strconv.Atoi(text)
-		if err == nil && i > 0 {
+		if strings.TrimSpace(text) == "systemd" {
 			result = true
 		}
+		/* i, err := strconv.Atoi(text)
+		if err == nil && i > 0 {
+			result = true
+		} */
 	}
 
 	err = cmd.Wait()

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
-	"github.com/sirupsen/logrus"
 )
 
 type WSLStubber struct {
@@ -260,14 +259,14 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		return fmt.Errorf("executing wait command: %w", err)
 	}
 
-	exitCmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
+	/* exitCmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
 	if err = exitCmd.Run(); err != nil {
 		return fmt.Errorf("stopping systemd: %w", err)
 	}
 
 	if err = cmd.Wait(); err != nil {
 		logrus.Warnf("Failed to wait for systemd to exit: (%s)", strings.TrimSpace(out.String()))
-	}
+	} */
 
 	return terminateDist(dist)
 }

--- a/pkg/machine/wsl/usermodenet.go
+++ b/pkg/machine/wsl/usermodenet.go
@@ -353,8 +353,20 @@ func changeDistUserModeNetworking(dist string, user string, image string, enable
 		return err
 	}
 
+	if err := appendSystemdConfig(dist); err != nil {
+		return err
+	}
+
 	if enable {
 		return appendDisableAutoResolve(dist)
+	}
+
+	return nil
+}
+
+func appendSystemdConfig(dist string) error {
+	if err := wslPipe(wslSystemdConf, dist, "sh", "-c", "cat >> /etc/wsl.conf"); err != nil {
+		return fmt.Errorf("could not append systemd config to wsl.conf: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
this commit is just to open a PR to make the modifications I did available and possibly discuss but it needs to be refined before merge/review.
I'll wait for the PR to "disable the ready check" as I could reuse the logic to cut off the podman scripts

In short what it does

1. It adds the logic to enable systemd using the wsl.conf file 
2. It removes all podman-centric initialization which are not really needed for non-podman VM
3. It updates the bootstrap script so that the WSL VM keeps running even if the user log off