### PR TITLE
Enable systemd through wsl.conf

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -48,6 +48,10 @@ ln -fs /usr/lib/systemd/system/podman.socket /etc/systemd/system/sockets.target.
 const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `
 
+const bootstrapSystemdConfig = `#!/bin/bash
+nohup bash -c 'while true; do sleep 60; done' >/dev/null 2>&1 &
+`
+
 const bootstrap = `#!/bin/bash
 ps -ef | grep -v grep | grep -q systemd && exit 0
 nohup unshare --kill-child --fork --pid --mount --mount-proc --propagation shared /lib/systemd/systemd >/dev/null 2>&1 &
@@ -62,6 +66,8 @@ or type exit. This also means to log out you need to exit twice.
 `
 
 const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
+
+const sysdpidSystemdConfig = "SYSDPID=`grep -q systemd /proc/1/comm && echo '1' || echo '0'`"
 
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then
@@ -93,6 +99,10 @@ fi
 
 const wslConf = `[user]
 default=[USER]
+`
+
+const wslSystemdConf = `[boot]
+systemd=true
 `
 
 const wslConfUserNet = `

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -71,9 +71,19 @@ func (w WSLStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConf
 	if err = configureSystem(mc, dist, mc.Ansible); err != nil {
 		return err
 	}
+	if mc.Capabilities.GetForwardSockets() {
+		if err = installScripts(dist); err != nil {
+			return err
+		}
+	} else {
+		if err := wslPipe(bootstrapSystemdConfig, dist, "sh", "-c",
+			"cat > /root/bootstrap; chmod 755 /root/bootstrap"); err != nil {
+			return fmt.Errorf("could not create bootstrap script for guest OS: %w", err)
+		}
 
-	if err = installScripts(dist); err != nil {
-		return err
+		if err := appendSystemdConfig(dist); err != nil {
+			return fmt.Errorf("could not update wsl.conf to enable systemd: %w", err)
+		}
 	}
 
 	if err = createKeys(mc, dist); err != nil {
@@ -150,7 +160,7 @@ func (w WSLStubber) SetProviderAttrs(mc *vmconfigs.MachineConfig, opts define.Se
 	}
 
 	if opts.UserModeNetworking != nil && mc.WSLHypervisor.UserModeNetworking != *opts.UserModeNetworking {
-		if running, _ := isRunning(mc.Name); running {
+		if running, _ := isRunning(mc); running {
 			return errors.New("user-mode networking can only be changed when the machine is not running")
 		}
 
@@ -211,7 +221,14 @@ func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool
 func (w WSLStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func() error, error) {
 	dist := env.WithToolPrefix(mc.Name)
 
-	err := wslInvoke(dist, "/root/bootstrap")
+	var err error
+	if mc.Capabilities.GetForwardSockets() {
+		err = wslInvoke(dist, "/root/bootstrap")
+	} else {
+		// By using sudo, the script is run on a different tty device than the user (e.g user pts/0, sudo pts/1)
+		// this tricks WSL to not shut down the VM even if the user is not logged in because there is still an interactive operation running.
+		err = wslInvoke(dist, "sudo", "/root/bootstrap")
+	}
 	if err != nil {
 		err = fmt.Errorf("the WSL bootstrap script failed: %w", err)
 	}
@@ -224,7 +241,7 @@ func (w WSLStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func() e
 }
 
 func (w WSLStubber) State(mc *vmconfigs.MachineConfig, bypass bool) (define.Status, error) {
-	running, err := isRunning(mc.Name)
+	running, err := isRunning(mc)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +256,7 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		err error
 	)
 
-	if running, err := isRunning(mc.Name); !running {
+	if running, err := isRunning(mc); !running {
 		return err
 	}
 
@@ -254,25 +271,25 @@ func (w WSLStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error {
 		if err := machine.StopWinProxy(mc.Name, vmtype); err != nil {
 			fmt.Fprintf(os.Stderr, "Could not stop API forwarding service (win-sshproxy.exe): %s\n", err.Error())
 		}
-	}
 
-	cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "sh")
-	cmd.Stdin = strings.NewReader(waitTerm)
-	out := &bytes.Buffer{}
-	cmd.Stderr = out
-	cmd.Stdout = out
+		cmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "sh")
+		cmd.Stdin = strings.NewReader(waitTerm)
+		out := &bytes.Buffer{}
+		cmd.Stderr = out
+		cmd.Stdout = out
 
-	if err = cmd.Start(); err != nil {
-		return fmt.Errorf("executing wait command: %w", err)
-	}
+		if err = cmd.Start(); err != nil {
+			return fmt.Errorf("executing wait command: %w", err)
+		}
 
-	exitCmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
-	if err = exitCmd.Run(); err != nil {
-		return fmt.Errorf("stopping systemd: %w", err)
-	}
+		exitCmd := exec.Command(wutil.FindWSL(), "-u", "root", "-d", dist, "/usr/local/bin/enterns", "systemctl", "exit", "0")
+		if err = exitCmd.Run(); err != nil {
+			return fmt.Errorf("stopping systemd: %w", err)
+		}
 
-	if err = cmd.Wait(); err != nil {
-		logrus.Warnf("Failed to wait for systemd to exit: (%s)", strings.TrimSpace(out.String()))
+		if err = cmd.Wait(); err != nil {
+			logrus.Warnf("Failed to wait for systemd to exit: (%s)", strings.TrimSpace(out.String()))
+		}
 	}
 
 	return terminateDist(dist)


### PR DESCRIPTION
this patch enables systemd by updating wsl.conf file in the VM. 

It updates the bootstrap script to start a process that simulate an active operation to maintain the VM running even if the user logs out.

