### PR TITLE
skip applyProxies on non podman machine

### DIFF
--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -557,8 +557,12 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 
 	// this expects to be able to ssh as root to the VM - switch to regular user + sudo?
 	// -> move it to a "PostStartVM()" interface method?
-	if err := proxyenv.ApplyProxies(mc); err != nil {
-		return err
+	// this is a temporary solution to skip applying proxies for non-podman machines bc of a problem with bootc/macadam
+	// however this should be replaced by a specific IsBootc property
+	if mc.Capabilities.GetForwardSockets() {
+		if err := proxyenv.ApplyProxies(mc); err != nil {
+			return err
+		}
 	}
 
 	// mount the volumes to the VM


### PR DESCRIPTION
this patch skips the ApplyProxies func with non podman machine. 
This is a temporary fix to allow using bootc images with macadam. Currently macadam fails at starting a bootc image VM because it expects user input when executing a sudo command.
Moreover, the command will try to create folders which should not be allowed in a read-only filesystem, so this should be skipped anyway