### PR TITLE
skip UpdateConnectionPairPort if podman is not active

### DIFF
--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -203,8 +203,10 @@ func reassignSSHPort(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	}
 
 	mc.SSH.Port = newPort
-	if err := connection.UpdateConnectionPairPort(mc.Name, newPort, mc.HostUser.UID, mc.SSH.RemoteUsername, mc.SSH.IdentityPath); err != nil {
-		return fmt.Errorf("could not update remote connection configuration: %w", err)
+	if mc.Capabilities.GetForwardSockets() {
+		if err := connection.UpdateConnectionPairPort(mc.Name, newPort, mc.HostUser.UID, mc.SSH.RemoteUsername, mc.SSH.IdentityPath); err != nil {
+			return fmt.Errorf("could not update remote connection configuration: %w", err)
+		}
 	}
 
 	// Write updated port back


### PR DESCRIPTION
when starting a VM if the ssh port chosen is already in use, it tries to reassign it. During this process it also fixes the connections saved previously and their ports. However if podman is not in use, this step should be skipped. E.g. when using macadam there is no concept of connections