### PR TITLE
skip retrieving QEMU Pid file if ready unit capability is disabled

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -123,23 +123,25 @@ func (q *QEMUStubber) StopVM(mc *vmconfigs.MachineConfig, _ bool) error {
 
 	// Make sure that the associated QEMU process gets killed in case it's
 	// still running (#16054).
-	qemuPid, err := qemuPid(mc.QEMUHypervisor.QEMUPidPath)
-	if err != nil {
-		if stopErr == nil {
-			return err
+	if mc.Capabilities.GetHasReadyUnit() {
+		qemuPid, err := qemuPid(mc.QEMUHypervisor.QEMUPidPath)
+		if err != nil {
+			if stopErr == nil {
+				return err
+			}
+			return fmt.Errorf("%w: %w", stopErr, err)
 		}
-		return fmt.Errorf("%w: %w", stopErr, err)
-	}
 
-	if qemuPid == -1 {
-		return stopErr
-	}
-
-	if err := sigKill(qemuPid); err != nil {
-		if stopErr == nil {
-			return err
+		if qemuPid == -1 {
+			return stopErr
 		}
-		return fmt.Errorf("%w: %w", stopErr, err)
+
+		if err := sigKill(qemuPid); err != nil {
+			if stopErr == nil {
+				return err
+			}
+			return fmt.Errorf("%w: %w", stopErr, err)
+		}
 	}
 
 	return stopErr


### PR DESCRIPTION
As the pid file gets created only if the readyUnit capability is enabled by setting the serial port in the qemu command when starting the VM, we also need to check if the readyUnit value is enabled when stopping the machine.

This patch fixes the issue that the user see the error <machine>_vm.pid: no such file or directory when stopping the VM