### PR TITLE
return custom error if remove action is cancelled

### DIFF
--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -3,6 +3,8 @@
 package machine
 
 import (
+	"errors"
+
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/libpod/events"
 	"github.com/containers/podman/v5/pkg/machine"
@@ -65,7 +67,7 @@ func rm(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := shim.Remove(mc, provider, dirs, destroyOptions); err != nil {
+	if err := shim.Remove(mc, provider, dirs, destroyOptions); err != nil && !errors.Is(err, shim.ErrRemoveUserCancelled) {
 		return err
 	}
 	newMachineEvent(events.Remove, events.Event{Name: vmName})

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var ErrRemoveUserCancelled = errors.New("user cancelled the removal operation")
+
 // List is done at the host level to allow for a *possible* future where
 // more than one provider is used
 func List(vmstubbers []vmconfigs.VMProvider, _ machine.ListOptions) ([]*machine.ListResponse, error) {
@@ -697,7 +699,7 @@ func Remove(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineD
 			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
-			return nil
+			return ErrRemoveUserCancelled
 		}
 	}
 


### PR DESCRIPTION
with the current code, the caller is not able to detect if the remove action succeeded or has been cancelled by the user. This patch returns a custom error for the cancelled outcome so the caller can detect it
