### PR TITLE
Enable cloud-init and system networking for hyperv provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/gvisor-tap-vsock v0.8.6
 	github.com/containers/image/v5 v5.35.0
-	github.com/containers/libhvee v0.10.0
+	github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5
 	github.com/containers/ocicrypt v1.2.1
 	github.com/containers/psgo v1.9.0
 	github.com/containers/storage v1.58.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/containers/gvisor-tap-vsock v0.8.6 h1:9SeAXK+K2o36CtrgYk6zRXbU3zrayjv
 github.com/containers/gvisor-tap-vsock v0.8.6/go.mod h1:+0mtKmm4STeSDnZe+DGnIwN4EH2f7AcWir7PwT28Ti0=
 github.com/containers/image/v5 v5.35.0 h1:T1OeyWp3GjObt47bchwD9cqiaAm/u4O4R9hIWdrdrP8=
 github.com/containers/image/v5 v5.35.0/go.mod h1:8vTsgb+1gKcBL7cnjyNOInhJQfTUQjJoO2WWkKDoebM=
-github.com/containers/libhvee v0.10.0 h1:7VLv8keWZpHuGmWvyY4c1mVH5V1JYb1G78VC+8AlrM0=
-github.com/containers/libhvee v0.10.0/go.mod h1:at0h8lRcK5jCKfQgU/e6Io0Mw12F36zRLjXVOXRoDTM=
+github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5 h1:wRVaP8192oHKkQ7hHLm+Dsq+08Mt4GKl4SDF/jhm5Cs=
+github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5/go.mod h1:MLfTB8sW7E2UwQ/WknTHbuiYtNpWCR9XENMhA/hm8h0=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/luksy v0.0.0-20250217190002-40bd943d93b8 h1:hAkmJxAYcNxgv7EsFY9sf1uIYhilYOQqjJ9UzCmYvzY=

--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -54,17 +54,19 @@ func (a *AppleHVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.Machin
 	}
 	mc.AppleHypervisor.Vfkit.Endpoint = localhostURI + ":" + strconv.Itoa(randPort)
 
-	virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
-	for _, mnt := range mc.Mounts {
-		virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
-	}
+	if ignBuilder != nil {
+		virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
+		for _, mnt := range mc.Mounts {
+			virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
+		}
 
-	// Populate the ignition file with virtiofs stuff
-	virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
-	if err != nil {
-		return err
+		// Populate the ignition file with virtiofs stuff
+		virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
+		if err != nil {
+			return err
+		}
+		ignBuilder.WithUnit(virtIOIgnitionMounts...)
 	}
-	ignBuilder.WithUnit(virtIOIgnitionMounts...)
 
 	cfg, err := config.Default()
 	if err != nil {

--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -34,7 +34,7 @@ func (a *AppleHVStubber) UserModeNetworkEnabled(_ *vmconfigs.MachineConfig) bool
 	return true
 }
 
-func (a *AppleHVStubber) UseProviderNetworkSetup() bool {
+func (a *AppleHVStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -17,7 +17,7 @@ type User struct {
 	Name    string   `yaml:"name"`
 	Sudo    string   `yaml:"sudo"`
 	Shell   string   `yaml:"shell"`
-	Groups  string   `yaml:"groups"`
+	Groups  []string `yaml:"groups"`
 	SSHKeys []string `yaml:"ssh_authorized_keys"`
 }
 
@@ -34,13 +34,11 @@ func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	userData := UserData{
 		Users: []User{
 			User{
-				Name:   mc.SSH.RemoteUsername,
-				Sudo:   "ALL=(ALL) NOPASSWD:ALL",
-				Shell:  "/bin/bash",
-				Groups: "users",
-				SSHKeys: []string{
-					sshKey,
-				},
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
 			},
 		},
 	}
@@ -91,6 +89,7 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (string, error) {
 			logrus.Error(err)
 		}
 	}()
+
 	userdata, err := GenerateUserData(mc)
 	if err != nil {
 		return "", nil

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -57,6 +57,16 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		Memory:   uint64(mc.Resources.Memory),
 	}
 
+	// HyperVHypervisor is initialized when preparing to use ignition, however hyperv also works with cloud-init
+	// so we need to ensure that HyperVHypervisor is initialized here as well.
+	if mc.HyperVHypervisor == nil {
+		mc.HyperVHypervisor = new(vmconfigs.HyperVConfig)
+	}
+
+	// Set userModeNetworking based on cloudInit value for backwards compatibility
+	// Usermode networking with hyperv requires gvforwarder in the guest, and the cloud init code cannot inject it for now,
+	// so it has to be disabled.
+	mc.HyperVHypervisor.UserModeNetworking = !mc.CloudInit
 	if mc.CloudInit {
 		// Generate cloud-init ISO
 		iso, err := cloudinit.GenerateISO(mc)

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -155,8 +156,10 @@ func (h HyperVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() err
 		// Remove ignition registry entries - not a fatal error
 		// for vm removal
 		// TODO we could improve this by recommending an action be done
-		if err := removeIgnitionFromRegistry(vm); err != nil {
-			logrus.Errorf("unable to remove ignition registry entries: %q", err)
+		if !mc.CloudInit {
+			if err := removeIgnitionFromRegistry(vm); err != nil {
+				logrus.Errorf("unable to remove ignition registry entries: %q", err)
+			}
 		}
 
 		// disk path removal is done by generic remove
@@ -215,15 +218,21 @@ func (h HyperVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func(
 		callbackFuncs.Add(rmIgnCallbackFunc)
 	}
 
-	waitReady, listener, err := mc.HyperVHypervisor.ReadyVsock.ListenSetupWait()
-	if err != nil {
-		return nil, nil, err
+	var waitReady func() error
+	var listener io.Closer
+	if mc.HyperVHypervisor.ReadyVsock.KeyName != "" {
+		waitReady, listener, err = mc.HyperVHypervisor.ReadyVsock.ListenSetupWait()
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	err = vm.Start()
 	if err != nil {
 		// cleanup the pending listener
-		_ = listener.Close()
+		if listener != nil {
+			_ = listener.Close()
+		}
 		return nil, nil, err
 	}
 
@@ -466,18 +475,22 @@ func resizeDisk(newSize strongunits.GiB, imagePath *define.VMFile) error {
 	return nil
 }
 
+func removeVsockFromRegistry(vsock vsock.HVSockRegistryEntry) {
+	if vsock.KeyName != "" {
+		if err := vsock.Remove(); err != nil {
+			logrus.Errorf("unable to remove registry entry for %s: %q", vsock.KeyName, err)
+		}
+	}
+}
+
 // removeNetworkAndReadySocketsFromRegistry removes the Network and Ready sockets
 // from the Windows Registry
 func removeNetworkAndReadySocketsFromRegistry(mc *vmconfigs.MachineConfig) {
 	// Remove the HVSOCK for networking
-	if err := mc.HyperVHypervisor.NetworkVSock.Remove(); err != nil {
-		logrus.Errorf("unable to remove registry entry for %s: %q", mc.HyperVHypervisor.NetworkVSock.KeyName, err)
-	}
+	removeVsockFromRegistry(mc.HyperVHypervisor.NetworkVSock)
 
 	// Remove the HVSOCK for events
-	if err := mc.HyperVHypervisor.ReadyVsock.Remove(); err != nil {
-		logrus.Errorf("unable to remove registry entry for %s: %q", mc.HyperVHypervisor.ReadyVsock.KeyName, err)
-	}
+	removeVsockFromRegistry(mc.HyperVHypervisor.ReadyVsock)
 }
 
 // readAndSplitIgnition reads the ignition file and splits it into key:value pairs

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -29,11 +29,11 @@ type HyperVStubber struct {
 }
 
 func (h HyperVStubber) UserModeNetworkEnabled(mc *vmconfigs.MachineConfig) bool {
-	return true
+	return mc.HyperVHypervisor.UserModeNetworking
 }
 
-func (h HyperVStubber) UseProviderNetworkSetup() bool {
-	return false
+func (h HyperVStubber) UseProviderNetworkSetup(mc *vmconfigs.MachineConfig) bool {
+	return mc.HyperVHypervisor.UserModeNetworking == false
 }
 
 func (h HyperVStubber) RequireExclusiveActive() bool {
@@ -55,12 +55,16 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		Memory:   uint64(mc.Resources.Memory),
 	}
 
-	networkHVSock, err := vsock.NewHVSockRegistryEntry(mc.Name, vsock.Network)
-	if err != nil {
-		return err
-	}
+	if mc.HyperVHypervisor.UserModeNetworking {
+		networkHVSock, err := vsock.NewHVSockRegistryEntry(mc.Name, vsock.Network)
+		if err != nil {
+			return err
+		}
 
-	mc.HyperVHypervisor.NetworkVSock = *networkHVSock
+		mc.HyperVHypervisor.NetworkVSock = *networkHVSock
+	} else {
+		hwConfig.Network = true
+	}
 
 	// Add vsock port numbers to mounts
 	err = createShares(mc)
@@ -164,7 +168,10 @@ func (h HyperVStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
 }
 
 func (h HyperVStubber) StartNetworking(mc *vmconfigs.MachineConfig, cmd *gvproxy.GvproxyCommand) error {
-	cmd.AddEndpoint(fmt.Sprintf("vsock://%s", mc.HyperVHypervisor.NetworkVSock.KeyName))
+	if mc.HyperVHypervisor.UserModeNetworking {
+		cmd.AddEndpoint(fmt.Sprintf("vsock://%s", mc.HyperVHypervisor.NetworkVSock.KeyName))
+		return nil
+	}
 	return nil
 }
 

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/containers/common/pkg/strongunits"
@@ -84,6 +87,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 
 		mc.HyperVHypervisor.NetworkVSock = *networkHVSock
 	} else {
+		mc.SSH.Port = 22
 		hwConfig.Network = true
 	}
 
@@ -412,6 +416,16 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo b
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal()
 
+	// If we are not using user mode networking, we need to retrieve the VM IP address
+	if !mc.HyperVHypervisor.UserModeNetworking {
+		ip, err := getVMIPAddress(mc.Name)
+		if err != nil {
+			return fmt.Errorf("retrieving VM's IP: %w", err)
+		}
+		mc.HyperVHypervisor.IPAddress = ip
+		return nil
+	}
+
 	if len(mc.Mounts) == 0 {
 		return nil
 	}
@@ -493,6 +507,44 @@ func resizeDisk(newSize strongunits.GiB, imagePath *define.VMFile) error {
 		return fmt.Errorf("resizing image: %q", err)
 	}
 	return nil
+}
+
+func getVMIPAddress(name string) (string, error) {
+	backoff := 500 * time.Millisecond
+	maxBackoffs := 6
+	for i := 0; i < maxBackoffs; i++ {
+		if i > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+		ip, err := getIPAddress(name)
+		if err != nil {
+			continue
+		}
+		return ip, nil
+	}
+	return "", fmt.Errorf("unable to retrieve IP address for VM %s after %d attempts", name, maxBackoffs)
+}
+
+func getIPAddress(name string) (string, error) {
+	ipAddress := exec.Command("powershell", []string{"-command", fmt.Sprintf("Get-VM -Name %s | Select-Object -ExpandProperty NetworkAdapters | Select-Object IPAddresses", name)}...)
+	logrus.Debug(ipAddress.Args)
+	var stdout bytes.Buffer
+	ipAddress.Stdout = &stdout
+	ipAddress.Stderr = os.Stderr
+	if err := ipAddress.Run(); err != nil {
+		return "", fmt.Errorf("resizing image: %q", err)
+	}
+	re := regexp.MustCompile(`\{(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}),.*?\}`)
+
+	matches := re.FindStringSubmatch(stdout.String())
+
+	if len(matches) > 1 {
+		ipv4Address := matches[1]
+		return ipv4Address, nil
+	}
+
+	return "", fmt.Errorf("could not extract IPv4 address from output: %s", strings.TrimSpace(stdout.String()))
 }
 
 func removeVsockFromRegistry(vsock vsock.HVSockRegistryEntry) {

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -83,29 +83,31 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	}
 	callbackFuncs.Add(removeRegistrySockets)
 
-	netUnitFile, err := createNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
-	if err != nil {
-		return err
-	}
+	if builder != nil {
+		netUnitFile, err := createNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+		if err != nil {
+			return err
+		}
 
-	builder.WithUnit(ignition.Unit{
-		Contents: ignition.StrToPtr(netUnitFile),
-		Enabled:  ignition.BoolToPtr(true),
-		Name:     "vsock-network.service",
-	})
+		builder.WithUnit(ignition.Unit{
+			Contents: ignition.StrToPtr(netUnitFile),
+			Enabled:  ignition.BoolToPtr(true),
+			Name:     "vsock-network.service",
+		})
 
-	builder.WithFile(ignition.File{
-		Node: ignition.Node{
-			Path: "/etc/NetworkManager/system-connections/vsock0.nmconnection",
-		},
-		FileEmbedded1: ignition.FileEmbedded1{
-			Append: nil,
-			Contents: ignition.Resource{
-				Source: ignition.EncodeDataURLPtr(hyperVVsockNMConnection),
+		builder.WithFile(ignition.File{
+			Node: ignition.Node{
+				Path: "/etc/NetworkManager/system-connections/vsock0.nmconnection",
 			},
-			Mode: ignition.IntToPtr(0600),
-		},
-	})
+			FileEmbedded1: ignition.FileEmbedded1{
+				Append: nil,
+				Contents: ignition.Resource{
+					Source: ignition.EncodeDataURLPtr(hyperVVsockNMConnection),
+				},
+				Mode: ignition.IntToPtr(0600),
+			},
+		})
+	}
 
 	vmm := hypervctl.NewVirtualMachineManager()
 	err = vmm.NewVirtualMachine(mc.Name, &hwConfig)
@@ -189,7 +191,7 @@ func (h HyperVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func(
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal()
 
-	if mc.IsFirstBoot() {
+	if mc.IsFirstBoot() && !mc.CloudInit {
 		// Add ignition entries to windows registry
 		// for first boot only
 		if err := readAndSplitIgnition(mc, vm); err != nil {

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -16,6 +16,7 @@ import (
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/libhvee/pkg/hypervctl"
 	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/cloudinit"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/hyperv/vsock"
@@ -54,6 +55,15 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		DiskPath: mc.ImagePath.GetPath(),
 		DiskSize: uint64(mc.Resources.DiskSize),
 		Memory:   uint64(mc.Resources.Memory),
+	}
+
+	if mc.CloudInit {
+		// Generate cloud-init ISO
+		iso, err := cloudinit.GenerateISO(mc)
+		if err != nil {
+			return fmt.Errorf("generating cloud-init ISO: %w", err)
+		}
+		hwConfig.DVDDiskPath = iso
 	}
 
 	if mc.HyperVHypervisor.UserModeNetworking {

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -123,7 +123,7 @@ func (l *LibKrunStubber) UserModeNetworkEnabled(mc *vmconfigs.MachineConfig) boo
 	return true
 }
 
-func (l *LibKrunStubber) UseProviderNetworkSetup() bool {
+func (l *LibKrunStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -39,17 +39,19 @@ func (l *LibKrunStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.Machin
 	}
 	mc.LibKrunHypervisor.KRun.Endpoint = localhostURI + ":" + strconv.Itoa(randPort)
 
-	virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
-	for _, mnt := range mc.Mounts {
-		virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
-	}
+	if builder != nil {
+		virtiofsMounts := make([]machine.VirtIoFs, 0, len(mc.Mounts))
+		for _, mnt := range mc.Mounts {
+			virtiofsMounts = append(virtiofsMounts, machine.MountToVirtIOFs(mnt))
+		}
 
-	// Populate the ignition file with virtiofs stuff
-	virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
-	if err != nil {
-		return err
+		// Populate the ignition file with virtiofs stuff
+		virtIOIgnitionMounts, err := apple.GenerateSystemDFilesForVirtiofsMounts(virtiofsMounts)
+		if err != nil {
+			return err
+		}
+		builder.WithUnit(virtIOIgnitionMounts...)
 	}
-	builder.WithUnit(virtIOIgnitionMounts...)
 
 	return apple.ResizeDisk(mc, mc.Resources.DiskSize)
 }

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -44,7 +44,7 @@ func (q *QEMUStubber) UserModeNetworkEnabled(*vmconfigs.MachineConfig) bool {
 	return true
 }
 
-func (q *QEMUStubber) UseProviderNetworkSetup() bool {
+func (q *QEMUStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -426,7 +426,7 @@ func stopLocked(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *mach
 	}
 
 	// Stop GvProxy and remove PID file
-	if !mp.UseProviderNetworkSetup() {
+	if !mp.UseProviderNetworkSetup(mc) {
 		gvproxyPidFile, err := dirs.RuntimeDir.AppendToNewVMFile("gvproxy.pid", nil)
 		if err != nil {
 			return err
@@ -625,7 +625,7 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 	}
 
 	// Provider is responsible for waiting
-	if mp.UseProviderNetworkSetup() {
+	if mp.UseProviderNetworkSetup(mc) {
 		return nil
 	}
 

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -175,11 +175,6 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 
 	logrus.Debugf("--> imagePath is %q", imagePath.GetPath())
 
-	ignitionFile, err := mc.IgnitionFile()
-	if err != nil {
-		return err
-	}
-
 	uid := os.Getuid()
 	if uid == -1 { // windows compensation
 		uid = 1000
@@ -195,32 +190,6 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		}
 	}
 
-	ignBuilder := ignition.NewIgnitionBuilder(ignition.DynamicIgnition{
-		Name:      userName,
-		Key:       sshKey,
-		TimeZone:  opts.TimeZone,
-		UID:       uid,
-		VMName:    opts.Name,
-		VMType:    mp.VMType(),
-		WritePath: ignitionFile.GetPath(),
-		Rootful:   opts.Rootful,
-	})
-
-	// If the user provides an ignition file, we need to
-	// copy it into the conf dir
-	if len(opts.IgnitionPath) > 0 {
-		err = ignBuilder.BuildWithIgnitionFile(opts.IgnitionPath)
-
-		if err != nil {
-			return err
-		}
-	} else {
-		err = ignBuilder.GenerateIgnitionConfig()
-		if err != nil {
-			return err
-		}
-	}
-
 	if len(opts.PlaybookPath) > 0 {
 		f, err := os.Open(opts.PlaybookPath)
 		if err != nil {
@@ -232,14 +201,6 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		}
 
 		playbookDest := fmt.Sprintf("/home/%s/%s", userName, "playbook.yaml")
-
-		if mp.VMType() != machineDefine.WSLVirt {
-			err = ignBuilder.AddPlaybook(string(s), playbookDest, userName)
-			if err != nil {
-				return err
-			}
-		}
-
 		mc.Ansible = &vmconfigs.AnsibleConfig{
 			PlaybookPath: playbookDest,
 			Contents:     string(s),
@@ -247,22 +208,64 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		}
 	}
 
-	readyIgnOpts, err := mp.PrepareIgnition(mc, &ignBuilder)
-	if err != nil {
-		return err
-	}
+	var ignBuilder *ignition.IgnitionBuilder
+	if !opts.CloudInit {
+		ignitionFile, err := mc.IgnitionFile()
+		if err != nil {
+			return err
+		}
 
-	readyUnitFile, err := ignition.CreateReadyUnitFile(mp.VMType(), readyIgnOpts)
-	if err != nil {
-		return err
-	}
+		tmpIgnBuilder := ignition.NewIgnitionBuilder(ignition.DynamicIgnition{
+			Name:      userName,
+			Key:       sshKey,
+			TimeZone:  opts.TimeZone,
+			UID:       uid,
+			VMName:    opts.Name,
+			VMType:    mp.VMType(),
+			WritePath: ignitionFile.GetPath(),
+			Rootful:   opts.Rootful,
+		})
+		ignBuilder = &tmpIgnBuilder
 
-	readyUnit := ignition.Unit{
-		Enabled:  ignition.BoolToPtr(true),
-		Name:     "ready.service",
-		Contents: ignition.StrToPtr(readyUnitFile),
+		// If the user provides an ignition file, we need to
+		// copy it into the conf dir
+		if len(opts.IgnitionPath) > 0 {
+			err = ignBuilder.BuildWithIgnitionFile(opts.IgnitionPath)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			err = ignBuilder.GenerateIgnitionConfig()
+			if err != nil {
+				return err
+			}
+		}
+
+		if mp.VMType() != machineDefine.WSLVirt && mc.Ansible != nil {
+			err = ignBuilder.AddPlaybook(mc.Ansible.Contents, mc.Ansible.PlaybookPath, userName)
+			if err != nil {
+				return err
+			}
+		}
+
+		readyIgnOpts, err := mp.PrepareIgnition(mc, ignBuilder)
+		if err != nil {
+			return err
+		}
+
+		readyUnitFile, err := ignition.CreateReadyUnitFile(mp.VMType(), readyIgnOpts)
+		if err != nil {
+			return err
+		}
+
+		readyUnit := ignition.Unit{
+			Enabled:  ignition.BoolToPtr(true),
+			Name:     "ready.service",
+			Contents: ignition.StrToPtr(readyUnitFile),
+		}
+		ignBuilder.WithUnit(readyUnit)
 	}
-	ignBuilder.WithUnit(readyUnit)
 
 	// TODO AddSSHConnectionToPodmanSocket could take an machineconfig instead
 	if mc.Capabilities.GetForwardSockets() {
@@ -280,12 +283,12 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		callbackFuncs.Add(cleanup)
 	}
 
-	err = mp.CreateVM(createOpts, mc, &ignBuilder)
+	err = mp.CreateVM(createOpts, mc, ignBuilder)
 	if err != nil {
 		return err
 	}
 
-	if len(opts.IgnitionPath) == 0 {
+	if len(opts.IgnitionPath) == 0 && !opts.CloudInit {
 		if err := ignBuilder.Build(); err != nil {
 			return err
 		}

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -100,7 +100,7 @@ func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	}
 
 	// Provider has its own networking code path (e.g. WSL)
-	if provider.UseProviderNetworkSetup() {
+	if provider.UseProviderNetworkSetup(mc) {
 		return "", 0, provider.StartNetworking(mc, nil)
 	}
 

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -92,7 +92,7 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 
 func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider) (string, machine.APIForwardingState, error) {
 	// Check if SSH port is in use, and reassign if necessary
-	if !ports.IsLocalPortAvailable(mc.SSH.Port) {
+	if provider.UserModeNetworkEnabled(mc) && !ports.IsLocalPortAvailable(mc.SSH.Port) {
 		logrus.Warnf("detected port conflict on machine ssh port [%d], reassigning", mc.SSH.Port)
 		if err := reassignSSHPort(mc, provider); err != nil {
 			return "", 0, err
@@ -145,7 +145,11 @@ func conductVMReadinessCheck(mc *vmconfigs.MachineConfig, maxBackoffs int, backo
 			sshError = ErrNotRunning
 			continue
 		}
-		if !isListening(mc.SSH.Port) {
+		address := "localhost"
+		if mc.HyperVHypervisor.IPAddress != "" {
+			address = mc.HyperVHypervisor.IPAddress
+		}
+		if !isListening(address, mc.SSH.Port) {
 			sshError = ErrSSHNotListening
 			continue
 		}
@@ -158,7 +162,7 @@ func conductVMReadinessCheck(mc *vmconfigs.MachineConfig, maxBackoffs int, backo
 		// CoreOS users have reported the same observation but
 		// the underlying source of the issue remains unknown.
 
-		if sshError = machine.CommonSSHSilent(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, []string{"true"}); sshError != nil {
+		if sshError = machine.CommonSSHSilentWithAddress(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, address, mc.SSH.Port, []string{"true"}); sshError != nil {
 			logrus.Debugf("SSH readiness check for machine failed: %v", sshError)
 			continue
 		}
@@ -218,9 +222,9 @@ func reassignSSHPort(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider)
 	return nil
 }
 
-func isListening(port int) bool {
+func isListening(address string, port int) bool {
 	// Check if we can dial it
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", "127.0.0.1", port), 10*time.Millisecond)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", address, port), 10*time.Millisecond)
 	if err != nil {
 		return false
 	}

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -17,28 +17,36 @@ import (
 // and a port
 // TODO This should probably be taught about an machineconfig to reduce input
 func CommonSSH(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, true, os.Stdin)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, true, os.Stdin)
+}
+
+func CommonSSHShellWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
+	return commonNativeSSH(username, identityPath, name, address, sshPort, inputArgs, os.Stdin)
 }
 
 func CommonSSHShell(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonNativeSSH(username, identityPath, name, sshPort, inputArgs, os.Stdin)
+	return CommonSSHShellWithAddress(username, identityPath, name, "localhost", sshPort, inputArgs)
 }
 
 func CommonSSHSilent(username, identityPath, name string, sshPort int, inputArgs []string) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, false, nil)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, false, nil)
 }
 
 func CommonSSHWithStdin(username, identityPath, name string, sshPort int, inputArgs []string, stdin io.Reader) error {
-	return commonBuiltinSSH(username, identityPath, name, sshPort, inputArgs, true, stdin)
+	return commonBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, true, stdin)
 }
 
-func commonBuiltinSSH(username, identityPath, name string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {
+func CommonSSHSilentWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
+	return commonBuiltinSSH(username, identityPath, name, address, sshPort, inputArgs, false, nil)
+}
+
+func commonBuiltinSSH(username, identityPath, name, address string, sshPort int, inputArgs []string, passOutput bool, stdin io.Reader) error {
 	config, err := createConfig(username, identityPath)
 	if err != nil {
 		return err
 	}
 
-	client, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%d", sshPort), config)
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", address, sshPort), config)
 	if err != nil {
 		return err
 	}
@@ -109,8 +117,8 @@ func createConfig(user string, identityPath string) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-func commonNativeSSH(username, identityPath, name string, sshPort int, inputArgs []string, stdin io.Reader) error {
-	sshDestination := username + "@localhost"
+func commonNativeSSH(username, identityPath, name, address string, sshPort int, inputArgs []string, stdin io.Reader) error {
+	sshDestination := username + "@" + address
 	port := strconv.Itoa(sshPort)
 	interactive := true
 

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -99,7 +99,7 @@ type VMProvider interface { //nolint:interfacebloat
 	StopHostNetworking(mc *MachineConfig, vmType define.VMType) error
 	VMType() define.VMType
 	UserModeNetworkEnabled(mc *MachineConfig) bool
-	UseProviderNetworkSetup() bool
+	UseProviderNetworkSetup(mc *MachineConfig) bool
 	RequireExclusiveActive() bool
 	UpdateSSHPort(mc *MachineConfig, port int) error
 	GetRosetta(mc *MachineConfig) (bool, error)

--- a/pkg/machine/vmconfigs/config_windows.go
+++ b/pkg/machine/vmconfigs/config_windows.go
@@ -7,6 +7,8 @@ import (
 )
 
 type HyperVConfig struct {
+	// Uses usermode networking
+	UserModeNetworking bool
 	// ReadyVSock is the pipeline for the guest to alert the host
 	// it is running
 	ReadyVsock vsock.HVSockRegistryEntry

--- a/pkg/machine/vmconfigs/config_windows.go
+++ b/pkg/machine/vmconfigs/config_windows.go
@@ -14,6 +14,7 @@ type HyperVConfig struct {
 	ReadyVsock vsock.HVSockRegistryEntry
 	// NetworkVSock is for the user networking
 	NetworkVSock vsock.HVSockRegistryEntry
+	IPAddress    string
 }
 
 type WSLConfig struct {

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -187,7 +187,7 @@ func (w WSLStubber) UserModeNetworkEnabled(mc *vmconfigs.MachineConfig) bool {
 	return mc.WSLHypervisor.UserModeNetworking
 }
 
-func (w WSLStubber) UseProviderNetworkSetup() bool {
+func (w WSLStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return true
 }
 

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm.go
@@ -430,7 +430,7 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 
-	if err := NewDriveSettingsBuilder(systemSettings).
+	builder := NewDriveSettingsBuilder(systemSettings).
 		AddScsiController().
 		AddSyntheticDiskDrive(0).
 		DefineVirtualHardDisk(config.DiskPath, func(vhdss *VirtualHardDiskStorageSettings) {
@@ -438,15 +438,24 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 			// vhdss.IOPSLimit = 5000
 		}).
 		Finish(). // disk
-		Finish(). // drive
-		//AddSyntheticDvdDrive(1).
-		//DefineVirtualDvdDisk(isoFile).
-		//Finish(). // disk
-		//Finish(). // drive
+		Finish()  // drive
+
+	if config.DVDDiskPath != "" {
+		// Add a DVD drive if the DVDDiskPath is set
+		// This is useful for cloud-init or other bootable media
+		builder = builder.
+			AddSyntheticDvdDrive(1).
+			DefineVirtualDvdDisk(config.DVDDiskPath).
+			Finish(). // disk
+			Finish()  // drive
+	}
+
+	if err := builder.
 		Finish(). // controller
 		Complete(); err != nil {
 		return err
 	}
+
 	// Add default network connection
 	if config.Network {
 		if err := NewNetworkSettingsBuilder(systemSettings).

--- a/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
+++ b/vendor/github.com/containers/libhvee/pkg/hypervctl/vm_config.go
@@ -101,6 +101,9 @@ type HardwareConfig struct {
 	// Network is bool to add a Network Connection to the
 	// default network switch in Microsoft HyperV
 	Network bool
+	// DVDDiskPath is the path to the disk image
+	// that will be used as a DVD drive in the VM (e.g. for cloud-init)
+	DVDDiskPath string
 }
 
 type Statuses struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -289,8 +289,8 @@ github.com/containers/image/v5/transports
 github.com/containers/image/v5/transports/alltransports
 github.com/containers/image/v5/types
 github.com/containers/image/v5/version
-# github.com/containers/libhvee v0.10.0
-## explicit; go 1.22.8
+# github.com/containers/libhvee v0.10.1-0.20250623125428-422aa7ddc0e5
+## explicit; go 1.23.3
 github.com/containers/libhvee/pkg/hypervctl
 github.com/containers/libhvee/pkg/kvp/ginsu
 github.com/containers/libhvee/pkg/wmiext


### PR DESCRIPTION
This PR has been built over https://github.com/cfergeau/podman/pull/8
It then adds the missing pieces to have a working workflow with macadam/hyperv (podman should work fine as before).

This contains several commits that do:
1. make ignition optional, so that if cloud-init is true, all ignition code is skipped
2. add code to generate the cloud-init config ISO - it will then be attached as a DVD drive to the VM
3. when using system networking, it retrieves the VM IP address and uses the default SSH port to connect to it