### PR TITLE
Move IPAddress to machineConfig

### DIFF
--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -422,7 +422,7 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo b
 		if err != nil {
 			return fmt.Errorf("retrieving VM's IP: %w", err)
 		}
-		mc.HyperVHypervisor.IPAddress = ip
+		mc.IPAddress = ip
 		return nil
 	}
 

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -145,10 +145,7 @@ func conductVMReadinessCheck(mc *vmconfigs.MachineConfig, maxBackoffs int, backo
 			sshError = ErrNotRunning
 			continue
 		}
-		address := "localhost"
-		if mc.HyperVHypervisor.IPAddress != "" {
-			address = mc.HyperVHypervisor.IPAddress
-		}
+		address := mc.GetAddress()
 		if !isListening(address, mc.SSH.Port) {
 			sshError = ErrSSHNotListening
 			continue

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -58,6 +58,7 @@ type MachineConfig struct {
 
 	CloudInit    bool
 	Capabilities *define.MachineCapabilities
+	IPAddress    string
 }
 
 type machineImage interface { //nolint:unused

--- a/pkg/machine/vmconfigs/config_windows.go
+++ b/pkg/machine/vmconfigs/config_windows.go
@@ -14,7 +14,6 @@ type HyperVConfig struct {
 	ReadyVsock vsock.HVSockRegistryEntry
 	// NetworkVSock is for the user networking
 	NetworkVSock vsock.HVSockRegistryEntry
-	IPAddress    string
 }
 
 type WSLConfig struct {

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -320,6 +320,13 @@ func (mc *MachineConfig) ConnectionInfo(vmtype define.VMType) (*define.VMFile, *
 	return socket, getPipe(mc.Name), err
 }
 
+func (mc *MachineConfig) GetAddress() string {
+	if mc.IPAddress != "" {
+		return mc.IPAddress
+	}
+	return "localhost"
+}
+
 // LoadMachineByName returns a machine config based on the vm name and provider
 func LoadMachineByName(name string, dirs *define.MachineDirs) (*MachineConfig, error) {
 	fullPath, err := dirs.ConfigDir.AppendToNewVMFile(name+".json", nil)


### PR DESCRIPTION
this patch moves the IPAddress field to machineConfig.

when working with different provider different from hyperv, HyperVHypervisor could be an empty struct and prompt error with IPAddress field