### PR TITLE
krunkit: Generate cloud-init iso

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -361,13 +361,21 @@ func getFirstBootAppleVMIgnition(mc *vmconfigs.MachineConfig) ([]string, error) 
 }
 
 func getFirstBootAppleVMCloudInit(mc *vmconfigs.MachineConfig) ([]string, error) {
-	// we generate the user-data file
-	userDataFile, err := cloudinit.GenerateUserDataFile(mc)
-	if err != nil {
-		return nil, err
-	}
+	if mc.LibKrunHypervisor == nil {
+		// we generate the user-data file
+		userDataFile, err := cloudinit.GenerateUserDataFile(mc)
+		if err != nil {
+			return nil, err
+		}
 
-	return []string{"--cloud-init", userDataFile}, nil
+		return []string{"--cloud-init", userDataFile}, nil
+	} else {
+		cloudinitISO, err := cloudinit.GenerateISO(mc)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"--device", fmt.Sprintf("virtio-blk,path=%s", cloudinitISO)}, nil
+	}
 }
 
 // CheckProcessRunning checks non blocking if the pid exited


### PR DESCRIPTION
This generates an ISO with the cloud-init data as krunkit does not support passing the user-data directly on the command-line.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
