### PR TITLE
Add support for custom cloud-init files

### DIFF
--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -91,14 +91,42 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		}
 	}()
 
-	userdata, err := GenerateUserData(mc)
-	if err != nil {
-		return nil, nil
+	userdata, metadata, networkConfig := []byte{}, []byte{}, []byte{}
+	if mc.CloudInitConfig.UserData != nil {
+		userdata, err = os.ReadFile(mc.CloudInitConfig.UserData.GetPath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read user-data file: %w", err)
+		}
 	}
+
+	if mc.CloudInitConfig.MetaData != nil {
+		metadata, err = os.ReadFile(mc.CloudInitConfig.MetaData.GetPath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read meta-data file: %w", err)
+		}
+	}
+
+	if mc.CloudInitConfig.NetworkConfig != nil {
+		networkConfig, err = os.ReadFile(mc.CloudInitConfig.NetworkConfig.GetPath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read network-config file: %w", err)
+		}
+	}
+
+	if len(userdata) == 0 && len(metadata) == 0 {
+		userdata, err = GenerateUserData(mc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate user-data: %w", err)
+		}
+	}
+
 	if err := writer.AddFile(bytes.NewReader(userdata), "user-data"); err != nil {
 		return nil, err
 	}
-	if err := writer.AddFile(bytes.NewReader([]byte{}), "meta-data"); err != nil {
+	if err := writer.AddFile(bytes.NewReader(metadata), "meta-data"); err != nil {
+		return nil, err
+	}
+	if err := writer.AddFile(bytes.NewReader(networkConfig), "network-config"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/machine/define/initopts.go
+++ b/pkg/machine/define/initopts.go
@@ -46,4 +46,5 @@ type InitOptions struct {
 	ImagePuller        ImagePuller
 	CloudInit          bool
 	Capabilities       *MachineCapabilities
+	CloudInitFiles     []string // user-data, meta-data and network-config cloud-init configuration file paths
 }

--- a/pkg/machine/shim/cloudinit.go
+++ b/pkg/machine/shim/cloudinit.go
@@ -1,0 +1,42 @@
+package shim
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+)
+
+func CmdLineCloudInitToConfig(files []string) (vmconfigs.CloudInitConfig, error) {
+	config := vmconfigs.CloudInitConfig{
+		UserData:      nil,
+		MetaData:      nil,
+		NetworkConfig: nil,
+	}
+	for _, file := range files {
+		_, err := os.Stat(file)
+		if errors.Is(err, os.ErrNotExist) {
+			return config, fmt.Errorf("cloud-initfile %s not found: %w", file, err)
+		}
+
+		filename := filepath.Base(file)
+		switch filename {
+		case "user-data":
+			config.UserData = &define.VMFile{
+				Path: file,
+			}
+		case "meta-data":
+			config.MetaData = &define.VMFile{
+				Path: file,
+			}
+		case "network-config":
+			config.NetworkConfig = &define.VMFile{
+				Path: file,
+			}
+		}
+	}
+	return config, nil
+}

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -139,6 +139,11 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 		mc.Mounts = CmdLineVolumesToMounts(opts.Volumes, mp.MountType())
 	}
 
+	mc.CloudInitConfig, err = CmdLineCloudInitToConfig(opts.CloudInitFiles)
+	if err != nil {
+		return err
+	}
+
 	// Issue #18230 ... do not mount over important directories at the / level (subdirs are fine)
 	for _, mnt := range mc.Mounts {
 		if err := validateDestinationPaths(mnt.Target); err != nil {

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -58,6 +58,14 @@ type MachineConfig struct {
 	CloudInit    bool
 	Capabilities *define.MachineCapabilities
 	IPAddress    string
+	// user-data, meta-data and network-config cloud-init configuration files
+	CloudInitConfig CloudInitConfig
+}
+
+type CloudInitConfig struct {
+	UserData      *define.VMFile
+	MetaData      *define.VMFile
+	NetworkConfig *define.VMFile
 }
 
 type VMProvider interface { //nolint:interfacebloat


### PR DESCRIPTION
This PR allows users to pass their own cloud-init files to the Init func.
Podman will then use them without generating its own user-data config file.