### PR TITLE
allow to customize number of max attempts for SSH readiness check

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -68,9 +68,10 @@ type SSHOptions struct {
 }
 
 type StartOptions struct {
-	NoInfo  bool
-	Quiet   bool
-	Rosetta bool
+	NoInfo      bool
+	Quiet       bool
+	Rosetta     bool
+	MaxBackoffs int
 }
 
 type StopOptions struct{}

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -578,6 +578,10 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 		return mp.State(mc, true)
 	}
 
+	if opts.MaxBackoffs > 0 {
+		maxBackoffs = opts.MaxBackoffs
+	}
+
 	connected, sshError, err := conductVMReadinessCheck(mc, maxBackoffs, defaultBackoff, stateF)
 	if err != nil {
 		return err


### PR DESCRIPTION
in certain scenario like when using self-sufficient bundle. SSH daemon needs more time to start and being able to answer.
The current code perform only 6 tries before give up. This should be made customizable so we could extend it when needed.