### PR TITLE
allow to update exclusiveActive value

### DIFF
--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -23,7 +23,8 @@ import (
 // and is required for network flow
 
 var (
-	vfkitCommand = "vfkit"
+	vfkitCommand    = "vfkit"
+	exclusiveActive = true
 )
 
 type AppleHVStubber struct {
@@ -38,8 +39,12 @@ func (a *AppleHVStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) boo
 	return false
 }
 
+func (a *AppleHVStubber) SetExclusiveActive(exclusive bool) {
+	exclusiveActive = exclusive
+}
+
 func (a *AppleHVStubber) RequireExclusiveActive() bool {
-	return true
+	return exclusiveActive
 }
 
 func (a *AppleHVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, ignBuilder *ignition.IgnitionBuilder) error {

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -34,6 +34,10 @@ type HyperVStubber struct {
 	vmconfigs.HyperVConfig
 }
 
+var (
+	exclusiveActive = true
+)
+
 func (h HyperVStubber) UserModeNetworkEnabled(mc *vmconfigs.MachineConfig) bool {
 	return mc.HyperVHypervisor.UserModeNetworking
 }
@@ -42,8 +46,12 @@ func (h HyperVStubber) UseProviderNetworkSetup(mc *vmconfigs.MachineConfig) bool
 	return mc.HyperVHypervisor.UserModeNetworking == false
 }
 
+func (h HyperVStubber) SetExclusiveActive(exclusive bool) {
+	exclusiveActive = exclusive
+}
+
 func (h HyperVStubber) RequireExclusiveActive() bool {
-	return true
+	return exclusiveActive
 }
 
 func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, builder *ignition.IgnitionBuilder) error {

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -22,6 +22,10 @@ const (
 	localhostURI  = "http://localhost"
 )
 
+var (
+	exclusiveActive = true
+)
+
 type LibKrunStubber struct {
 	vmconfigs.AppleHVConfig
 }
@@ -129,8 +133,12 @@ func (l *LibKrunStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) boo
 	return false
 }
 
+func (l *LibKrunStubber) SetExclusiveActive(exclusive bool) {
+	exclusiveActive = exclusive
+}
+
 func (l *LibKrunStubber) RequireExclusiveActive() bool {
-	return true
+	return exclusiveActive
 }
 
 func (l *LibKrunStubber) UpdateSSHPort(mc *vmconfigs.MachineConfig, port int) error {

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -38,6 +38,7 @@ type QEMUStubber struct {
 var (
 	gvProxyWaitBackoff        = 500 * time.Millisecond
 	gvProxyMaxBackoffAttempts = 6
+	exclusiveActive           = true
 )
 
 func (q *QEMUStubber) UserModeNetworkEnabled(*vmconfigs.MachineConfig) bool {
@@ -48,8 +49,12 @@ func (q *QEMUStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return false
 }
 
+func (q *QEMUStubber) SetExclusiveActive(exclusive bool) {
+	exclusiveActive = exclusive
+}
+
 func (q *QEMUStubber) RequireExclusiveActive() bool {
-	return true
+	return exclusiveActive
 }
 
 func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -101,6 +101,7 @@ type VMProvider interface { //nolint:interfacebloat
 	VMType() define.VMType
 	UserModeNetworkEnabled(mc *MachineConfig) bool
 	UseProviderNetworkSetup(mc *MachineConfig) bool
+	SetExclusiveActive(exclusive bool)
 	RequireExclusiveActive() bool
 	UpdateSSHPort(mc *MachineConfig, port int) error
 	GetRosetta(mc *MachineConfig) (bool, error)

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -25,6 +25,10 @@ type WSLStubber struct {
 	vmconfigs.WSLConfig
 }
 
+var (
+	exclusiveActive = false
+)
+
 func (w WSLStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, _ *ignition.IgnitionBuilder) error {
 	var (
 		err error
@@ -191,8 +195,12 @@ func (w WSLStubber) UseProviderNetworkSetup(_ *vmconfigs.MachineConfig) bool {
 	return true
 }
 
+func (w WSLStubber) SetExclusiveActive(exclusive bool) {
+	exclusiveActive = exclusive
+}
+
 func (w WSLStubber) RequireExclusiveActive() bool {
-	return false
+	return exclusiveActive
 }
 
 func (w WSLStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo bool) error {


### PR DESCRIPTION
podman does not allow to run multiple VM at the same time, except for WSL. However, macadam should allow it with all providers. This patch adds a set func to update the exclusiveActive value and allow to run multiple VMs simultaneously.
The default behavior does not change.