### PR TITLE
Centralize how gvproxy PID and Log paths are calculated

### DIFF
--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
 // CleanupGVProxy reads the --pid-file for gvproxy attempts to stop it
@@ -28,4 +29,12 @@ func CleanupGVProxy(f define.VMFile) error {
 		return err
 	}
 	return removeGVProxyPIDFile(f)
+}
+
+func GetGVProxyPIDFile(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) (*define.VMFile, error) {
+	return dirs.RuntimeDir.AppendToNewVMFile(fmt.Sprintf("gvproxy-%s.pid", mc.Name), nil)
+}
+
+func GetGVProxyLogFile(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) (*define.VMFile, error) {
+	return dirs.RuntimeDir.AppendToNewVMFile(fmt.Sprintf("gvproxy-%s.log", mc.Name), nil)
 }

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -448,7 +448,7 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, noInfo b
 		return err
 	}
 	// GvProxy PID file path is now derived
-	gvproxyPIDFile, err := dirs.RuntimeDir.AppendToNewVMFile("gvproxy.pid", nil)
+	gvproxyPIDFile, err := machine.GetGVProxyPIDFile(mc, dirs)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -437,7 +437,7 @@ func stopLocked(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *mach
 
 	// Stop GvProxy and remove PID file
 	if !mp.UseProviderNetworkSetup(mc) {
-		gvproxyPidFile, err := dirs.RuntimeDir.AppendToNewVMFile("gvproxy.pid", nil)
+		gvproxyPidFile, err := machine.GetGVProxyPIDFile(mc, dirs)
 		if err != nil {
 			return err
 		}
@@ -523,7 +523,7 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 		}
 	}()
 
-	gvproxyPidFile, err := dirs.RuntimeDir.AppendToNewVMFile("gvproxy.pid", nil)
+	gvproxyPidFile, err := machine.GetGVProxyPIDFile(mc, dirs)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -54,10 +53,17 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 	cmd := gvproxy.NewGvproxyCommand()
 
 	// GvProxy PID file path is now derived
-	runDir := dirs.RuntimeDir
-	cmd.PidFile = filepath.Join(runDir.GetPath(), "gvproxy.pid")
+	gvproxyPIDFile, err := machine.GetGVProxyPIDFile(mc, dirs)
+	if err != nil {
+		return err
+	}
+	cmd.PidFile = gvproxyPIDFile.GetPath()
 
-	cmd.LogFile = filepath.Join(runDir.GetPath(), "gvproxy.log")
+	gvproxyLogFile, err := machine.GetGVProxyLogFile(mc, dirs)
+	if err != nil {
+		return err
+	}
+	cmd.LogFile = gvproxyLogFile.GetPath()
 
 	cmd.SSHPort = mc.SSH.Port
 


### PR DESCRIPTION
The gvproxy pid and log files were consistently generated using the same code in different places.
This patch centralizes them into two func.

related to https://github.com/crc-org/macadam/issues/225