### PR TITLE
Fix multiple VMs with QEMU

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -381,7 +381,7 @@ func getFirstBootAppleVMCloudInit(mc *vmconfigs.MachineConfig) ([]string, error)
 		if err != nil {
 			return nil, err
 		}
-		return []string{"--device", fmt.Sprintf("virtio-blk,path=%s", cloudinitISO)}, nil
+		return []string{"--device", fmt.Sprintf("virtio-blk,path=%s", cloudinitISO.GetPath())}, nil
 	}
 }
 

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -107,7 +107,7 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		return nil, err
 	}
 
-	vmFile, err := machineDataDir.AppendToNewVMFile(("cloudinit.iso"), nil)
+	vmFile, err := machineDataDir.AppendToNewVMFile(fmt.Sprintf("%s-cloudinit.iso", mc.Name), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/kdomanski/iso9660"
 	"github.com/sirupsen/logrus"
@@ -78,10 +79,10 @@ func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
 	return path, nil
 }
 
-func GenerateISO(mc *vmconfigs.MachineConfig) (string, error) {
+func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	writer, err := iso9660.NewWriter()
 	if err != nil {
-		return "", fmt.Errorf("failed to create writer: %w", err)
+		return nil, fmt.Errorf("failed to create writer: %w", err)
 	}
 
 	defer func() {
@@ -92,25 +93,28 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (string, error) {
 
 	userdata, err := GenerateUserData(mc)
 	if err != nil {
-		return "", nil
+		return nil, nil
 	}
 	if err := writer.AddFile(bytes.NewReader(userdata), "user-data"); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := writer.AddFile(bytes.NewReader([]byte{}), "meta-data"); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	machineDataDir, err := mc.DataDir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	path := filepath.Join(machineDataDir.GetPath(), "cloudinit.iso")
-
-	isoFile, err := os.Create(path)
+	vmFile, err := machineDataDir.AppendToNewVMFile(("cloudinit.iso"), nil)
 	if err != nil {
-		return "", fmt.Errorf("unable to create cloud-init ISO file: %w", err)
+		return nil, err
+	}
+
+	isoFile, err := os.Create(vmFile.GetPath())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create cloud-init ISO file: %w", err)
 	}
 
 	defer func() {
@@ -122,8 +126,8 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (string, error) {
 	err = writer.WriteTo(isoFile, "cidata")
 	if err != nil {
 		os.Remove(isoFile.Name())
-		return "", fmt.Errorf("failed to write cloud-init ISO image: %w", err)
+		return nil, fmt.Errorf("failed to write cloud-init ISO image: %w", err)
 	}
 
-	return isoFile.Name(), nil
+	return vmFile, nil
 }

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -85,7 +85,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		if err != nil {
 			return fmt.Errorf("generating cloud-init ISO: %w", err)
 		}
-		hwConfig.DVDDiskPath = iso
+		hwConfig.DVDDiskPath = iso.GetPath()
 	}
 
 	if mc.HyperVHypervisor.UserModeNetworking {

--- a/pkg/machine/qemu/command/command.go
+++ b/pkg/machine/qemu/command/command.go
@@ -99,6 +99,11 @@ func (q *QemuCmd) SetBootableImage(image string) {
 	*q = append(*q, "-drive", "if=virtio,file="+image)
 }
 
+// SetISOImage specifies the image the machine will use to boot
+func (q *QemuCmd) SetISOImage(image string) {
+	*q = append(*q, "-drive", "if=virtio,media=cdrom,format=raw,file="+image)
+}
+
 // SetDisplay specifies whether the machine will have a display
 func (q *QemuCmd) SetDisplay(display string) {
 	*q = append(*q, "-display", display)

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -76,7 +76,7 @@ func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
 		if err != nil {
 			return err
 		}
-		q.Command.SetISOImage(cloudInitISO)
+		q.Command.SetISOImage(cloudInitISO.GetPath())
 	} else {
 		ignitionFile, err := mc.IgnitionFile()
 		if err != nil {

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -76,7 +76,7 @@ func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
 		if err != nil {
 			return err
 		}
-		q.Command.SetBootableImage(cloudInitISO)
+		q.Command.SetISOImage(cloudInitISO)
 	} else {
 		ignitionFile, err := mc.IgnitionFile()
 		if err != nil {


### PR DESCRIPTION
This fixes an issue with multiple VMs on linux, the second VM could not start because it was trying to use the same cloud-init.iso file as the first VM.