### PR TITLE
delete lock file when the machine gets removed

### DIFF
--- a/pkg/machine/lock/lock.go
+++ b/pkg/machine/lock/lock.go
@@ -8,8 +8,12 @@ import (
 	"github.com/containers/storage/pkg/lockfile"
 )
 
+func GetMachineLockPath(name string, machineConfigDir string) string {
+	return filepath.Join(machineConfigDir, name+".lock")
+}
+
 func GetMachineLock(name string, machineConfigDir string) (*lockfile.LockFile, error) {
-	lockPath := filepath.Join(machineConfigDir, name+".lock")
+	lockPath := GetMachineLockPath(name, machineConfigDir)
 	lock, err := lockfile.GetLockFile(lockPath)
 	if err != nil {
 		return nil, fmt.Errorf("creating lockfile for VM: %w", err)

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -686,7 +686,16 @@ func Set(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machineDefin
 
 func Remove(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDefine.MachineDirs, opts machine.RemoveOptions) error {
 	mc.Lock()
-	defer mc.Unlock()
+	defer func() {
+		mc.Unlock()
+
+		// Remove the lock file
+		lockPath := lock.GetMachineLockPath(mc.Name, dirs.ConfigDir.GetPath())
+		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+			logrus.Errorf("failed to remove lock file at %s: %v", lockPath, err)
+			return
+		}
+	}()
 	if err := mc.Refresh(); err != nil {
 		return fmt.Errorf("reload config: %w", err)
 	}


### PR DESCRIPTION
Ensure lock files are properly removed from the config directory when a machine is deleted

related to https://github.com/crc-org/macadam/issues/239