### PR TITLE
Remove EFI vars store and ignition socket when removing machine

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -9,12 +9,14 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/strongunits"
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/containers/podman/v5/pkg/errorhandling"
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/cloudinit"
 	"github.com/containers/podman/v5/pkg/machine/define"
@@ -334,6 +336,15 @@ func StartGenericAppleVM(mc *vmconfigs.MachineConfig, cmdBinary string, bootload
 	return cmd.Process.Release, returnFunc, nil
 }
 
+func ignitionSocket(dataDir *define.VMFile, name string) (*define.VMFile, error) {
+	socketName := fmt.Sprintf("%s-%s", name, ignitionSocketName)
+	return dataDir.AppendToNewVMFile(socketName, &socketName)
+}
+
+func EfiVarsPath(dataDir *define.VMFile, name string) string {
+	return filepath.Join(dataDir.GetPath(), "efi-bl-"+name)
+}
+
 func getFirstBootAppleVMIgnition(mc *vmconfigs.MachineConfig) ([]string, error) {
 	machineDataDir, err := mc.DataDir()
 	if err != nil {
@@ -342,8 +353,7 @@ func getFirstBootAppleVMIgnition(mc *vmconfigs.MachineConfig) ([]string, error) 
 
 	// If this is the first boot of the vm, we need to add the vsock
 	// device to vfkit so we can inject the ignition file
-	socketName := fmt.Sprintf("%s-%s", mc.Name, ignitionSocketName)
-	ignitionSocket, err := machineDataDir.AppendToNewVMFile(socketName, &socketName)
+	ignitionSocket, err := ignitionSocket(machineDataDir, mc.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -418,4 +428,39 @@ func StartGenericNetworking(mc *vmconfigs.MachineConfig, cmd *gvproxy.GvproxyCom
 	}
 	cmd.AddVfkitSocket(fmt.Sprintf("unixgram://%s", gvProxySock.GetPath()))
 	return nil
+}
+
+func Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
+	dataDir, err := mc.DataDir()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rmFiles := []string{}
+
+	efiVarsPath := EfiVarsPath(dataDir, mc.Name)
+	rmFiles = append(rmFiles, efiVarsPath)
+
+	ignitionSocket, err := ignitionSocket(dataDir, mc.Name)
+	if err == nil {
+		rmFiles = append(rmFiles, ignitionSocket.GetPath())
+	}
+
+	rmFunc := func() error {
+		var errs []error
+
+		if err := os.Remove(efiVarsPath); err != nil {
+			errs = append(errs, err)
+		}
+
+		if ignitionSocket != nil {
+			if err := ignitionSocket.Delete(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		return errorhandling.JoinErrors(errs)
+	}
+
+	return rmFiles, rmFunc, nil
 }

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -3,12 +3,13 @@
 package applehv
 
 import (
+	"github.com/containers/podman/v5/pkg/machine/apple"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 )
 
 func (a *AppleHVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
-	return []string{}, func() error { return nil }, nil
+	return apple.Remove(mc)
 }
 
 func (a *AppleHVStubber) State(mc *vmconfigs.MachineConfig, _ bool) (define.Status, error) {

--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -50,7 +50,7 @@ func (a *AppleHVStubber) RequireExclusiveActive() bool {
 func (a *AppleHVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineConfig, ignBuilder *ignition.IgnitionBuilder) error {
 	mc.AppleHypervisor = new(vmconfigs.AppleHVConfig)
 	mc.AppleHypervisor.Vfkit = vfkit.Helper{}
-	bl := vfConfig.NewEFIBootloader(fmt.Sprintf("%s/efi-bl-%s", opts.Dirs.DataDir.GetPath(), opts.Name), true)
+	bl := vfConfig.NewEFIBootloader(apple.EfiVarsPath(opts.Dirs.DataDir, opts.Name), true)
 	mc.AppleHypervisor.Vfkit.VirtualMachine = vfConfig.NewVirtualMachine(uint(mc.Resources.CPUs), uint64(mc.Resources.Memory), bl)
 
 	randPort, err := utils.GetRandomPort()

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -34,7 +34,7 @@ func (l *LibKrunStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.Machin
 	mc.LibKrunHypervisor = new(vmconfigs.LibKrunConfig)
 	mc.LibKrunHypervisor.KRun = vfkit.Helper{}
 
-	bl := vfConfig.NewEFIBootloader(fmt.Sprintf("%s/efi-bl-%s", opts.Dirs.DataDir.GetPath(), opts.Name), true)
+	bl := vfConfig.NewEFIBootloader(apple.EfiVarsPath(opts.Dirs.DataDir, opts.Name), true)
 	mc.LibKrunHypervisor.KRun.VirtualMachine = vfConfig.NewVirtualMachine(uint(mc.Resources.CPUs), uint64(mc.Resources.Memory), bl)
 
 	randPort, err := utils.GetRandomPort()
@@ -78,7 +78,7 @@ func (l *LibKrunStubber) MountVolumesToVM(mc *vmconfigs.MachineConfig, quiet boo
 }
 
 func (l *LibKrunStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
-	return []string{}, func() error { return nil }, nil
+	return apple.Remove(mc)
 }
 
 func (l *LibKrunStubber) RemoveAndCleanMachines(dirs *define.MachineDirs) error {


### PR DESCRIPTION
These 2 files were left-over when running `macadam rm`