### PR TITLE
delete cloudInit ISO file when VM is removed

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -446,6 +446,11 @@ func Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
 		rmFiles = append(rmFiles, ignitionSocket.GetPath())
 	}
 
+	cloudinitISO, err := cloudinit.GetCloudInitISOVMFile(mc)
+	if err == nil {
+		rmFiles = append(rmFiles, cloudinitISO.GetPath())
+	}
+
 	rmFunc := func() error {
 		var errs []error
 
@@ -455,6 +460,12 @@ func Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
 
 		if ignitionSocket != nil {
 			if err := ignitionSocket.Delete(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if cloudinitISO != nil {
+			if err := cloudinitISO.Delete(); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -79,6 +79,14 @@ func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
 	return path, nil
 }
 
+func GetCloudInitISOVMFile(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
+	machineDataDir, err := mc.DataDir()
+	if err != nil {
+		return nil, err
+	}
+	return machineDataDir.AppendToNewVMFile(fmt.Sprintf("%s-cloudinit.iso", mc.Name), nil)
+}
+
 func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	writer, err := iso9660.NewWriter()
 	if err != nil {
@@ -102,12 +110,7 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		return nil, err
 	}
 
-	machineDataDir, err := mc.DataDir()
-	if err != nil {
-		return nil, err
-	}
-
-	vmFile, err := machineDataDir.AppendToNewVMFile(fmt.Sprintf("%s-cloudinit.iso", mc.Name), nil)
+	vmFile, err := GetCloudInitISOVMFile(mc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when using cloud-init an ISO with all config files is generated to be used when the VM gets started. However this file is never deleted even when the VM is removed. This patch fixes it and handle the deletion of the cloud ISO file.