### PR TITLE
Add support for user-mode networking on Hyperv using cloud-init

### DIFF
--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -6,12 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/kdomanski/iso9660"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 type User struct {
@@ -24,36 +22,6 @@ type User struct {
 
 type UserData struct {
 	Users []User `yaml:"users"`
-}
-
-func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
-	if err != nil {
-		return nil, err
-	}
-
-	userData := UserData{
-		Users: []User{
-			User{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
-		},
-	}
-
-	yamlBytes, err := yaml.Marshal(&userData)
-	if err != nil {
-		logrus.Errorf("Error marshaling to YAML: %v", err)
-		return nil, err
-	}
-
-	headerLine := "#cloud-config\n"
-	yamlBytes = append([]byte(headerLine), yamlBytes...)
-
-	return yamlBytes, nil
 }
 
 func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -20,8 +20,24 @@ type User struct {
 	SSHKeys []string `yaml:"ssh_authorized_keys"`
 }
 
+type WriteFile struct {
+	Path        string `yaml:"path,omitempty"`
+	Content     string `yaml:"content,omitempty"`
+	Encoding    string `yaml:"encoding,omitempty"`
+	Owner       string `yaml:"owner,omitempty"`
+	Permissions string `yaml:"permissions,omitempty"`
+}
+
 type UserData struct {
-	Users []User `yaml:"users"`
+	Users      []User      `yaml:"users"`
+	WriteFiles []WriteFile `yaml:"write_files,omitempty"`
+	RunCmd     []string    `yaml:"runcmd,omitempty"`
+	Mounts     [][]string  `yaml:"mounts,omitempty"`
+}
+
+type EmbeddedResource struct {
+	Name    string `yaml:"name"`
+	Content []byte `yaml:"content"`
 }
 
 func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
@@ -104,6 +120,15 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 	if err := writer.AddFile(bytes.NewReader(networkConfig), "network-config"); err != nil {
 		return nil, err
+	}
+
+	resources := GetEmbeddedResources(mc)
+	if resources != nil {
+		for _, res := range resources {
+			if err := writer.AddFile(bytes.NewReader(res.Content), res.Name); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	vmFile, err := GetCloudInitISOVMFile(mc)

--- a/pkg/machine/cloudinit/cloudinit_unix.go
+++ b/pkg/machine/cloudinit/cloudinit_unix.go
@@ -38,3 +38,7 @@ func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 
 	return yamlBytes, nil
 }
+
+func GetEmbeddedResources(_ *vmconfigs.MachineConfig) []EmbeddedResource {
+	return nil
+}

--- a/pkg/machine/cloudinit/cloudinit_unix.go
+++ b/pkg/machine/cloudinit/cloudinit_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package cloudinit
+
+import (
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	userData := UserData{
+		Users: []User{
+			User{
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
+			},
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(&userData)
+	if err != nil {
+		logrus.Errorf("Error marshaling to YAML: %v", err)
+		return nil, err
+	}
+
+	headerLine := "#cloud-config\n"
+	yamlBytes = append([]byte(headerLine), yamlBytes...)
+
+	return yamlBytes, nil
+}

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package cloudinit
+
+import (
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	userData := UserData{
+		Users: []User{
+			User{
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
+			},
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(&userData)
+	if err != nil {
+		logrus.Errorf("Error marshaling to YAML: %v", err)
+		return nil, err
+	}
+
+	headerLine := "#cloud-config\n"
+	yamlBytes = append([]byte(headerLine), yamlBytes...)
+
+	return yamlBytes, nil
+}

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -3,7 +3,13 @@
 package cloudinit
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -27,6 +33,39 @@ func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 		},
 	}
 
+	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
+		netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+		if err != nil {
+			return nil, err
+		}
+
+		userData.WriteFiles = []WriteFile{
+			{
+				Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
+				Content:     hutil.HyperVVsockNMConnection,
+				Permissions: "0600",
+				Owner:       "root",
+			},
+			{
+				Path:        "/etc/systemd/system/vsock-network.service",
+				Content:     netUnitFile,
+				Permissions: "0644",
+				Owner:       "root",
+			},
+		}
+
+		userData.RunCmd = []string{
+			"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
+			"nmcli connection reload",
+			"systemctl daemon-reload",
+			"systemctl enable --now vsock-network.service",
+		}
+
+		userData.Mounts = [][]string{
+			{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},
+		}
+	}
+
 	yamlBytes, err := yaml.Marshal(&userData)
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
@@ -35,6 +74,88 @@ func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 
 	headerLine := "#cloud-config\n"
 	yamlBytes = append([]byte(headerLine), yamlBytes...)
-
 	return yamlBytes, nil
+}
+
+func getGvForwarderBytes() ([]byte, error) {
+	url, err := getGvForwarderDownloadUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download gvforwarder: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download gvforwarder: %s", resp.Status)
+	}
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gvforwarder response body: %w", err)
+	}
+
+	return bytes, nil
+}
+
+func getGvForwarderDownloadUrl() (string, error) {
+	apiURL := "https://api.github.com/repos/containers/gvisor-tap-vsock/releases/latest"
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get latest gvforwarder release information: %s", resp.Status)
+	}
+
+	var releaseInfo struct {
+		Assets []struct {
+			Name        string `json:"name"`
+			DownloadUrl string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releaseInfo); err != nil {
+		return "", err
+	}
+
+	for _, asset := range releaseInfo.Assets {
+		if asset.Name == "gvforwarder" {
+			return asset.DownloadUrl, nil
+		}
+	}
+
+	return "", fmt.Errorf("gvforwarder latest release not found")
+}
+
+func GetEmbeddedResources(mc *vmconfigs.MachineConfig) []EmbeddedResource {
+	// Only add gvforwarder if using Hyper-V with user-mode networking
+	if mc.HyperVHypervisor == nil || !mc.HyperVHypervisor.UserModeNetworking {
+		return nil
+	}
+
+	extraFiles := []EmbeddedResource{}
+	gvforwarderBytes, err := getGvForwarderBytes()
+	if err != nil {
+		logrus.Errorf("Failed to get gvforwarder: %v", err)
+		return extraFiles
+	}
+	extraFiles = append(extraFiles, EmbeddedResource{
+		Name:    "gvforwarder",
+		Content: gvforwarderBytes,
+	})
+	return extraFiles
 }

--- a/pkg/machine/hyperv/hutil/hutil.go
+++ b/pkg/machine/hyperv/hutil/hutil.go
@@ -1,0 +1,35 @@
+package hutil
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v5/pkg/systemd/parser"
+)
+
+const HyperVVsockNMConnection = `
+[connection]
+id=vsock0
+type=tun
+interface-name=vsock0
+
+[tun]
+mode=2
+
+[802-3-ethernet]
+cloned-mac-address=5A:94:EF:E4:0C:EE
+
+[ipv4]
+method=auto
+
+[proxy]
+`
+
+func CreateNetworkUnit(netPort uint64) (string, error) {
+	netUnit := parser.NewUnitFile()
+	netUnit.Add("Unit", "Description", "vsock_network")
+	netUnit.Add("Unit", "After", "NetworkManager.service")
+	netUnit.Add("Service", "ExecStart", fmt.Sprintf("/usr/libexec/podman/gvforwarder -preexisting -iface vsock0 -url vsock://2:%d/connect", netPort))
+	netUnit.Add("Service", "ExecStartPost", "/usr/bin/nmcli c up vsock0")
+	netUnit.Add("Install", "WantedBy", "multi-user.target")
+	return netUnit.ToString()
+}

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -77,17 +77,9 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	}
 
 	// Set userModeNetworking based on cloudInit value for backwards compatibility
-	// Usermode networking with hyperv requires gvforwarder in the guest, and the cloud init code cannot inject it for now,
-	// so it has to be disabled.
-	mc.HyperVHypervisor.UserModeNetworking = !mc.CloudInit
-	if mc.CloudInit {
-		// Generate cloud-init ISO
-		iso, err := cloudinit.GenerateISO(mc)
-		if err != nil {
-			return fmt.Errorf("generating cloud-init ISO: %w", err)
-		}
-		hwConfig.DVDDiskPath = iso.GetPath()
-	}
+	// Usermode networking is true by default when working with ignition
+	// If cloud-init is enabled, use userModeNetworking from options
+	mc.HyperVHypervisor.UserModeNetworking = !mc.CloudInit || opts.UserModeNetworking
 
 	if mc.HyperVHypervisor.UserModeNetworking {
 		networkHVSock, err := vsock.NewHVSockRegistryEntry(mc.Name, vsock.Network)
@@ -99,6 +91,15 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	} else {
 		mc.SSH.Port = 22
 		hwConfig.Network = true
+	}
+
+	if mc.CloudInit {
+		// Generate cloud-init ISO
+		iso, err := cloudinit.GenerateISO(mc)
+		if err != nil {
+			return fmt.Errorf("generating cloud-init ISO: %w", err)
+		}
+		hwConfig.DVDDiskPath = iso.GetPath()
 	}
 
 	// Add vsock port numbers to mounts

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -24,10 +24,10 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/cloudinit"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
+	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
 	"github.com/containers/podman/v5/pkg/machine/hyperv/vsock"
 	"github.com/containers/podman/v5/pkg/machine/ignition"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
-	"github.com/containers/podman/v5/pkg/systemd/parser"
 	"github.com/sirupsen/logrus"
 )
 
@@ -119,7 +119,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	callbackFuncs.Add(removeRegistrySockets)
 
 	if builder != nil {
-		netUnitFile, err := createNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+		netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 			FileEmbedded1: ignition.FileEmbedded1{
 				Append: nil,
 				Contents: ignition.Resource{
-					Source: ignition.EncodeDataURLPtr(hyperVVsockNMConnection),
+					Source: ignition.EncodeDataURLPtr(hutil.HyperVVsockNMConnection),
 				},
 				Mode: ignition.IntToPtr(0600),
 			},
@@ -646,34 +646,6 @@ func logCommandToFile(c *exec.Cmd, filename string) (*os.File, error) {
 	c.Stderr = log
 
 	return log, nil
-}
-
-const hyperVVsockNMConnection = `
-[connection]
-id=vsock0
-type=tun
-interface-name=vsock0
-
-[tun]
-mode=2
-
-[802-3-ethernet]
-cloned-mac-address=5A:94:EF:E4:0C:EE
-
-[ipv4]
-method=auto
-
-[proxy]
-`
-
-func createNetworkUnit(netPort uint64) (string, error) {
-	netUnit := parser.NewUnitFile()
-	netUnit.Add("Unit", "Description", "vsock_network")
-	netUnit.Add("Unit", "After", "NetworkManager.service")
-	netUnit.Add("Service", "ExecStart", fmt.Sprintf("/usr/libexec/podman/gvforwarder -preexisting -iface vsock0 -url vsock://2:%d/connect", netPort))
-	netUnit.Add("Service", "ExecStartPost", "/usr/bin/nmcli c up vsock0")
-	netUnit.Add("Install", "WantedBy", "multi-user.target")
-	return netUnit.ToString()
 }
 
 func (h HyperVStubber) GetRosetta(mc *vmconfigs.MachineConfig) (bool, error) {


### PR DESCRIPTION
if usermode networking is enabled on hyperv we need to inject
gvforwarder and set up the vsock connection and a systemd service to
handle it.

To do this we create a custom user-data having all the data to inject in
the guest.

The resulting user-data is similar to https://github.com/crc-org/macadam/issues/228#issuecomment-3210712139