### PR TITLE
Fix error message when deleting libkrun machine

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -454,7 +454,7 @@ func Remove(mc *vmconfigs.MachineConfig) ([]string, func() error, error) {
 	rmFunc := func() error {
 		var errs []error
 
-		if err := os.Remove(efiVarsPath); err != nil {
+		if err := os.Remove(efiVarsPath); err != nil && !os.IsNotExist(err) {
 			errs = append(errs, err)
 		}
 

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -200,7 +200,7 @@ func (q *QEMUStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func()
 	cmdLine := q.Command
 
 	// Disable graphic window when not in debug mode
-	// Done in start, so we're not suck with the debug level we used on init
+	// Done in start, so we're not stuck with the debug level we used on init
 	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmdLine.SetDisplay("none")
 	}


### PR DESCRIPTION
The efi-bl file does not always exist with krunkit VMs, which causes an error when running `macadam rm`. This PR ignores non-existing files in `Remove` implementation as is done in other places.