### PR TITLE
Allow to attach user-mode networking config to user's custom user-data file

### DIFF
--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -155,6 +155,7 @@ func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
 	header := textproto.MIMEHeader{}
 	// Set the specific Content-Type that cloud-init recognizes for configuration files
 	header.Set("Content-Type", "text/cloud-config")
+	header.Set("Merge-Type", "list(append)+dict(no_replace,recurse_list)+str()")
 
 	partWriter, err := writer.CreatePart(header)
 	if err != nil {

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -3,9 +3,12 @@ package cloudinit
 import (
 	"bytes"
 	"fmt"
+	"mime/multipart"
+	"net/textproto"
 	"os"
 	"path/filepath"
 
+	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/kdomanski/iso9660"
@@ -41,7 +44,7 @@ type EmbeddedResource struct {
 }
 
 func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
-	yamlBytes, err := GenerateUserData(mc)
+	yamlBytes, err := generateUserData(mc)
 	if err != nil {
 		return "", err
 	}
@@ -83,12 +86,11 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		}
 	}()
 
-	userdata, metadata, networkConfig := []byte{}, []byte{}, []byte{}
-	if mc.CloudInitConfig.UserData != nil {
-		userdata, err = mc.CloudInitConfig.UserData.Read()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read user-data file: %w", err)
-		}
+	metadata, networkConfig := []byte{}, []byte{}
+
+	userdata, err := generateUserData(mc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate user-data file: %w", err)
 	}
 
 	if mc.CloudInitConfig.MetaData != nil {
@@ -102,13 +104,6 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		networkConfig, err = mc.CloudInitConfig.NetworkConfig.Read()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read network-config file: %w", err)
-		}
-	}
-
-	if len(userdata) == 0 && len(metadata) == 0 {
-		userdata, err = GenerateUserData(mc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate user-data: %w", err)
 		}
 	}
 
@@ -154,4 +149,39 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 
 	return vmFile, nil
+}
+
+func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
+	header := textproto.MIMEHeader{}
+	// Set the specific Content-Type that cloud-init recognizes for configuration files
+	header.Set("Content-Type", "text/cloud-config")
+
+	partWriter, err := writer.CreatePart(header)
+	if err != nil {
+		return fmt.Errorf("failed to create new MIME part: %w", err)
+	}
+
+	if _, err := partWriter.Write(content); err != nil {
+		return fmt.Errorf("failed to write content to MIME part: %w", err)
+	}
+	return nil
+}
+
+func getDefaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {
+	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserData{
+		Users: []User{
+			User{
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
+			},
+		},
+	}, nil
 }

--- a/pkg/machine/cloudinit/cloudinit_unix.go
+++ b/pkg/machine/cloudinit/cloudinit_unix.go
@@ -3,40 +3,37 @@
 package cloudinit
 
 import (
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
-func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+func generateDefaultUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	userData, err := getDefaultUserData(mc)
 	if err != nil {
 		return nil, err
 	}
 
-	userData := UserData{
-		Users: []User{
-			User{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
-		},
-	}
-
-	yamlBytes, err := yaml.Marshal(&userData)
+	userDataBytes, err := yaml.Marshal(&userData)
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
 		return nil, err
 	}
 
 	headerLine := "#cloud-config\n"
-	yamlBytes = append([]byte(headerLine), yamlBytes...)
+	userDataBytes = append([]byte(headerLine), userDataBytes...)
 
-	return yamlBytes, nil
+	return userDataBytes, nil
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	// If user has not provided any custom user-data, generate default
+	// otherwise use the provided one
+	if mc.CloudInitConfig.UserData == nil {
+		return generateDefaultUserData(mc)
+	}
+
+	return mc.CloudInitConfig.UserData.Read()
 }
 
 func GetEmbeddedResources(_ *vmconfigs.MachineConfig) []EmbeddedResource {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -3,78 +3,124 @@
 package cloudinit
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
-func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) error {
+	netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	userData := UserData{
-		Users: []User{
-			User{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
+	userData.WriteFiles = []WriteFile{
+		{
+			Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
+			Content:     hutil.HyperVVsockNMConnection,
+			Permissions: "0600",
+			Owner:       "root",
+		},
+		{
+			Path:        "/etc/systemd/system/vsock-network.service",
+			Content:     netUnitFile,
+			Permissions: "0644",
+			Owner:       "root",
 		},
 	}
 
-	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
-		netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+	userData.RunCmd = []string{
+		"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
+		"nmcli connection reload",
+		"systemctl daemon-reload",
+		"systemctl enable --now vsock-network.service",
+	}
+
+	userData.Mounts = [][]string{
+		{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},
+	}
+
+	return nil
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	var err error
+	// If user has not provided any custom user-data, generate default
+	// otherwise use the provided one and just add user-mode networking part if needed
+	internalUserData := &UserData{}
+	if mc.CloudInitConfig.UserData == nil {
+		internalUserData, err = getDefaultUserData(mc)
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		userData.WriteFiles = []WriteFile{
-			{
-				Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
-				Content:     hutil.HyperVVsockNMConnection,
-				Permissions: "0600",
-				Owner:       "root",
-			},
-			{
-				Path:        "/etc/systemd/system/vsock-network.service",
-				Content:     netUnitFile,
-				Permissions: "0644",
-				Owner:       "root",
-			},
-		}
-
-		userData.RunCmd = []string{
-			"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
-			"nmcli connection reload",
-			"systemctl daemon-reload",
-			"systemctl enable --now vsock-network.service",
-		}
-
-		userData.Mounts = [][]string{
-			{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},
+	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
+		err = setUserModeNetworkingPart(internalUserData, mc)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	yamlBytes, err := yaml.Marshal(&userData)
+	internalUserDataBytes, err := yaml.Marshal(internalUserData)
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
 		return nil, err
 	}
 
 	headerLine := "#cloud-config\n"
-	yamlBytes = append([]byte(headerLine), yamlBytes...)
-	return yamlBytes, nil
+	internalUserDataBytes = append([]byte(headerLine), internalUserDataBytes...)
+
+	// If user has not provided any custom user-data, return the generated one
+	if mc.CloudInitConfig.UserData == nil {
+		return internalUserDataBytes, nil
+	}
+
+	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
+	userUserData, err := mc.CloudInitConfig.UserData.Read()
+	if err != nil {
+		return nil, err
+	}
+	if mc.HyperVHypervisor != nil && !mc.HyperVHypervisor.UserModeNetworking {
+		return userUserData, nil
+	}
+
+	// if user has provided a custom user-data and we are on Hyper-V/user-mode networking,
+	// we need to merge our generated user data with user's one
+	// To do it we create a MIME multi-part archive
+	// with both files
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+
+	// add our configuration as the first part
+	if err := createCloudConfigPart(writer, internalUserDataBytes); err != nil {
+		return nil, fmt.Errorf("failed to create internal cloud-config part: %w", err)
+	}
+
+	// Add the user's config as a second part
+	if err := createCloudConfigPart(writer, userUserData); err != nil {
+		return nil, fmt.Errorf("failed to create user cloud-config part: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// finalize mime archive with top-level header
+	finalContent := new(bytes.Buffer)
+	topLevelHeader := fmt.Sprintf("Content-Type: multipart/mixed; boundary=%s\nMIME-Version: 1.0\n\n", writer.Boundary())
+	finalContent.WriteString(topLevelHeader)
+	finalContent.Write(buf.Bytes())
+
+	return finalContent.Bytes(), nil
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -17,7 +17,7 @@ import (
 )
 
 func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) error {
-	netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+	netUnitFile, err := hutil.CreateNetworkUnitWithBinary("/usr/local/bin/gvforwarder", mc.HyperVHypervisor.NetworkVSock.Port)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/hyperv/hutil/hutil.go
+++ b/pkg/machine/hyperv/hutil/hutil.go
@@ -6,8 +6,7 @@ import (
 	"github.com/containers/podman/v5/pkg/systemd/parser"
 )
 
-const HyperVVsockNMConnection = `
-[connection]
+const HyperVVsockNMConnection = `[connection]
 id=vsock0
 type=tun
 interface-name=vsock0

--- a/pkg/machine/hyperv/hutil/hutil.go
+++ b/pkg/machine/hyperv/hutil/hutil.go
@@ -23,12 +23,16 @@ method=auto
 [proxy]
 `
 
-func CreateNetworkUnit(netPort uint64) (string, error) {
+func CreateNetworkUnitWithBinary(binaryPath string, netPort uint64) (string, error) {
 	netUnit := parser.NewUnitFile()
 	netUnit.Add("Unit", "Description", "vsock_network")
 	netUnit.Add("Unit", "After", "NetworkManager.service")
-	netUnit.Add("Service", "ExecStart", fmt.Sprintf("/usr/libexec/podman/gvforwarder -preexisting -iface vsock0 -url vsock://2:%d/connect", netPort))
+	netUnit.Add("Service", "ExecStart", fmt.Sprintf("%s -preexisting -iface vsock0 -url vsock://2:%d/connect", binaryPath, netPort))
 	netUnit.Add("Service", "ExecStartPost", "/usr/bin/nmcli c up vsock0")
 	netUnit.Add("Install", "WantedBy", "multi-user.target")
 	return netUnit.ToString()
+}
+
+func CreateNetworkUnit(netPort uint64) (string, error) {
+	return CreateNetworkUnitWithBinary("/usr/libexec/podman/gvforwarder", netPort)
 }


### PR DESCRIPTION
This PR contains the logic to merge a custom user data with the one we generate for user-mode networking.
It was part of https://github.com/cfergeau/podman/pull/31 but it was split to a different PR for easier review.

This commit was born after this discussion https://github.com/cfergeau/podman/pull/31#discussion_r2419212993

It should work this way

- custom user-data + system networking = we use user's user-data without any change and do not add any extra file to the iso
- NO custom user-data + system networking = we generate a default user-data having the core user/ssh set (no extra file is added to the iso)
- custom user-data + user-mode networking = we merge user's user-data with one created by us that contains what's needed to set/run gvforwarder + add gvforwarder binary in iso
- NO custom user-data + user-mode networking = we generate a default user-data having the core user/ssh set and gvforwarder stuff + gvforwarder binary in iso