### PR TITLE
run `gvproxy` with its services API enabled

### DIFF
--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/ports"
+	"github.com/containers/podman/v5/pkg/machine/sockets"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 )
@@ -74,6 +75,17 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 		cmd.AddForwardUser(forwardUser)
 		cmd.AddForwardIdentity(mc.SSH.IdentityPath)
 	}
+
+	// add REST API services endpoint
+	serviceSocketPath, err := mc.GVProxyServiceSocket()
+	if err != nil {
+		return err
+	}
+	serviceEndpoint, err := sockets.ToUnixURL(serviceSocketPath)
+	if err != nil {
+		return err
+	}
+	cmd.AddServiceEndpoint(serviceEndpoint.String())
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd.Debug = true

--- a/pkg/machine/vmconfigs/machine.go
+++ b/pkg/machine/vmconfigs/machine.go
@@ -287,6 +287,14 @@ func (mc *MachineConfig) GVProxySocket() (*define.VMFile, error) {
 	return gvProxySocket(mc.Name, machineRuntimeDir)
 }
 
+func (mc *MachineConfig) GVProxyServiceSocket() (*define.VMFile, error) {
+	machineRuntimeDir, err := mc.RuntimeDir()
+	if err != nil {
+		return nil, err
+	}
+	return gvProxyServicesSocket(mc.Name, machineRuntimeDir)
+}
+
 func (mc *MachineConfig) APISocket() (*define.VMFile, error) {
 	machineRuntimeDir, err := mc.RuntimeDir()
 	if err != nil {

--- a/pkg/machine/vmconfigs/sockets.go
+++ b/pkg/machine/vmconfigs/sockets.go
@@ -19,3 +19,8 @@ func readySocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFile,
 func apiSocket(name string, socketDir *define.VMFile) (*define.VMFile, error) {
 	return socketDir.AppendToNewVMFile(name+"-api.sock", nil)
 }
+
+func gvProxyServicesSocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFile, error) {
+	endpoint := fmt.Sprintf("%s-gvproxy-api.sock", name)
+	return machineRuntimeDir.AppendToNewVMFile(endpoint, nil)
+}

--- a/pkg/machine/vmconfigs/sockets_darwin.go
+++ b/pkg/machine/vmconfigs/sockets_darwin.go
@@ -20,3 +20,8 @@ func apiSocket(name string, socketDir *define.VMFile) (*define.VMFile, error) {
 	socketName := name + "-api.sock"
 	return socketDir.AppendToNewVMFile(socketName, &socketName)
 }
+
+func gvProxyServicesSocket(name string, machineRuntimeDir *define.VMFile) (*define.VMFile, error) {
+	endpoint := fmt.Sprintf("%s-gvproxy-api.sock", name)
+	return machineRuntimeDir.AppendToNewVMFile(endpoint, &endpoint)
+}


### PR DESCRIPTION
if we need to add DNS entries or port forwarding for a VM
then the gvproxy process provides an API to add those dns
records or port forwards, but currently it is ran without
a listener for the rest API

this change adds a helper to get a path in the VM runtime
dir for a unix socket which can be used to expose the API