### PR TITLE
Add support for --cloud-init + --user-mode-networking

### DIFF
--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -3,6 +3,8 @@ package cloudinit
 import (
 	"bytes"
 	"fmt"
+	"mime/multipart"
+	"net/textproto"
 	"os"
 	"path/filepath"
 
@@ -147,6 +149,22 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 
 	return vmFile, nil
+}
+
+func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
+	header := textproto.MIMEHeader{}
+	// Set the specific Content-Type that cloud-init recognizes for configuration files
+	header.Set("Content-Type", "text/cloud-config")
+
+	partWriter, err := writer.CreatePart(header)
+	if err != nil {
+		return fmt.Errorf("failed to create new MIME part: %w", err)
+	}
+
+	if _, err := partWriter.Write(content); err != nil {
+		return fmt.Errorf("failed to write content to MIME part: %w", err)
+	}
+	return nil
 }
 
 func getDefaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/kdomanski/iso9660"
@@ -41,7 +42,7 @@ type EmbeddedResource struct {
 }
 
 func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
-	yamlBytes, err := GenerateUserData(mc)
+	yamlBytes, err := generateUserData(mc)
 	if err != nil {
 		return "", err
 	}
@@ -83,12 +84,11 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		}
 	}()
 
-	userdata, metadata, networkConfig := []byte{}, []byte{}, []byte{}
-	if mc.CloudInitConfig.UserData != nil {
-		userdata, err = mc.CloudInitConfig.UserData.Read()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read user-data file: %w", err)
-		}
+	metadata, networkConfig := []byte{}, []byte{}
+
+	userdata, err := generateUserData(mc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate user-data file: %w", err)
 	}
 
 	if mc.CloudInitConfig.MetaData != nil {
@@ -102,13 +102,6 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 		networkConfig, err = mc.CloudInitConfig.NetworkConfig.Read()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read network-config file: %w", err)
-		}
-	}
-
-	if len(userdata) == 0 && len(metadata) == 0 {
-		userdata, err = GenerateUserData(mc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate user-data: %w", err)
 		}
 	}
 
@@ -154,4 +147,23 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 
 	return vmFile, nil
+}
+
+func getDefaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {
+	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserData{
+		Users: []User{
+			User{
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
+			},
+		},
+	}, nil
 }

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -118,11 +118,9 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 
 	resources := GetEmbeddedResources(mc)
-	if resources != nil {
-		for _, res := range resources {
-			if err := writer.AddFile(bytes.NewReader(res.Content), res.Name); err != nil {
-				return nil, err
-			}
+	for _, res := range resources {
+		if err := writer.AddFile(bytes.NewReader(res.Content), res.Name); err != nil {
+			return nil, err
 		}
 	}
 
@@ -175,7 +173,7 @@ func getDefaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {
 
 	return &UserData{
 		Users: []User{
-			User{
+			{
 				Name:    mc.SSH.RemoteUsername,
 				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
 				Shell:   "/bin/bash",

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -8,40 +8,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/kdomanski/iso9660"
 	"github.com/sirupsen/logrus"
 )
-
-type User struct {
-	Name    string   `yaml:"name"`
-	Sudo    string   `yaml:"sudo"`
-	Shell   string   `yaml:"shell"`
-	Groups  []string `yaml:"groups"`
-	SSHKeys []string `yaml:"ssh_authorized_keys"`
-}
-
-type WriteFile struct {
-	Path        string `yaml:"path,omitempty"`
-	Content     string `yaml:"content,omitempty"`
-	Encoding    string `yaml:"encoding,omitempty"`
-	Owner       string `yaml:"owner,omitempty"`
-	Permissions string `yaml:"permissions,omitempty"`
-}
-
-type UserData struct {
-	Users      []User      `yaml:"users"`
-	WriteFiles []WriteFile `yaml:"write_files,omitempty"`
-	RunCmd     []string    `yaml:"runcmd,omitempty"`
-	Mounts     [][]string  `yaml:"mounts,omitempty"`
-}
-
-type EmbeddedResource struct {
-	Name    string `yaml:"name"`
-	Content []byte `yaml:"content"`
-}
 
 func GenerateUserDataFile(mc *vmconfigs.MachineConfig) (string, error) {
 	yamlBytes, err := generateUserData(mc)
@@ -163,23 +134,4 @@ func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
 		return fmt.Errorf("failed to write content to MIME part: %w", err)
 	}
 	return nil
-}
-
-func getDefaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &UserData{
-		Users: []User{
-			{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
-		},
-	}, nil
 }

--- a/pkg/machine/cloudinit/cloudinit.go
+++ b/pkg/machine/cloudinit/cloudinit.go
@@ -3,8 +3,6 @@ package cloudinit
 import (
 	"bytes"
 	"fmt"
-	"mime/multipart"
-	"net/textproto"
 	"os"
 	"path/filepath"
 
@@ -118,20 +116,4 @@ func GenerateISO(mc *vmconfigs.MachineConfig) (*define.VMFile, error) {
 	}
 
 	return vmFile, nil
-}
-
-func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
-	header := textproto.MIMEHeader{}
-	// Set the specific Content-Type that cloud-init recognizes for configuration files
-	header.Set("Content-Type", "text/cloud-config")
-
-	partWriter, err := writer.CreatePart(header)
-	if err != nil {
-		return fmt.Errorf("failed to create new MIME part: %w", err)
-	}
-
-	if _, err := partWriter.Write(content); err != nil {
-		return fmt.Errorf("failed to write content to MIME part: %w", err)
-	}
-	return nil
 }

--- a/pkg/machine/cloudinit/cloudinit_unix.go
+++ b/pkg/machine/cloudinit/cloudinit_unix.go
@@ -3,40 +3,37 @@
 package cloudinit
 
 import (
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
-func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+func generateDefaultUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	userData, err := getDefaultUserData(mc)
 	if err != nil {
 		return nil, err
 	}
 
-	userData := UserData{
-		Users: []User{
-			User{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
-		},
-	}
-
-	yamlBytes, err := yaml.Marshal(&userData)
+	userDataBytes, err := yaml.Marshal(&userData)
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
 		return nil, err
 	}
 
 	headerLine := "#cloud-config\n"
-	yamlBytes = append([]byte(headerLine), yamlBytes...)
+	userDataBytes = append([]byte(headerLine), userDataBytes...)
 
-	return yamlBytes, nil
+	return userDataBytes, nil
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	// If user has not provided any custom user-data, generate default
+	// otherwise use the provided one
+	if mc.CloudInitConfig.UserData == nil {
+		return generateDefaultUserData(mc)
+	}
+
+	return mc.CloudInitConfig.UserData.Read()
 }
 
 func GetEmbeddedResources(_ *vmconfigs.MachineConfig) []EmbeddedResource {

--- a/pkg/machine/cloudinit/cloudinit_unix.go
+++ b/pkg/machine/cloudinit/cloudinit_unix.go
@@ -4,26 +4,15 @@ package cloudinit
 
 import (
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 func generateDefaultUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	userData, err := getDefaultUserData(mc)
+	userData, err := defaultUserData(mc)
 	if err != nil {
 		return nil, err
 	}
 
-	userDataBytes, err := yaml.Marshal(&userData)
-	if err != nil {
-		logrus.Errorf("Error marshaling to YAML: %v", err)
-		return nil, err
-	}
-
-	headerLine := "#cloud-config\n"
-	userDataBytes = append([]byte(headerLine), userDataBytes...)
-
-	return userDataBytes, nil
+	return userData.Marshal()
 }
 
 func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) error {
+func addUserModeNetworking(userData *UserData, mc *vmconfigs.MachineConfig) error {
 	netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
 	if err != nil {
 		return err
@@ -48,44 +48,53 @@ func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) 
 	return nil
 }
 
-func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	var err error
-	// If user has not provided any custom user-data, generate default
-	// otherwise use the provided one and just add user-mode networking part if needed
-	internalUserData := &UserData{}
-	if mc.CloudInitConfig.UserData == nil {
-		internalUserData, err = defaultUserData(mc)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
-		err = setUserModeNetworkingPart(internalUserData, mc)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// If user has not provided any custom user-data, return the generated one
-	if mc.CloudInitConfig.UserData == nil {
-		return internalUserData.Marshal()
-	}
-
-	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
-	userUserData, err := mc.CloudInitConfig.UserData.Read()
+func defaultHypervUserData(mc *vmconfigs.MachineConfig, userModeNetworking bool) ([]byte, error) {
+	userData, err := defaultUserData(mc)
 	if err != nil {
 		return nil, err
 	}
-	if mc.HyperVHypervisor != nil && !mc.HyperVHypervisor.UserModeNetworking {
-		return userUserData, nil
+
+	if userModeNetworking {
+		err = addUserModeNetworking(userData, mc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// if user has provided a custom user-data and we are on Hyper-V/user-mode networking,
+	return userData.Marshal()
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	var err error
+	userModeNetworking := mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking
+
+	// If user has not provided any custom user-data, generate default
+	if mc.CloudInitConfig.UserData == nil {
+		return defaultHypervUserData(mc, userModeNetworking)
+	}
+
+	customUserData, err := mc.CloudInitConfig.UserData.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
+	if !userModeNetworking {
+		return customUserData, nil
+	}
+
+	// otherwise use the custom user-data and add the user-mode networking configuration
+	userModeNetworkingUserData := &UserData{}
+
+	if err := addUserModeNetworking(userModeNetworkingUserData, mc); err != nil {
+		return nil, err
+	}
+
+	// if the user has provided a custom user-data and we are on Hyper-V/user-mode networking,
 	// we need to merge our generated user data with user's one
 	// To do it we create a MIME multi-part archive
 	// with both files
-	return internalUserData.MarshalMultiPart(userUserData)
+	return userModeNetworkingUserData.MarshalMultiPart(customUserData)
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -3,9 +3,11 @@
 package cloudinit
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 
 	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
@@ -87,8 +89,38 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if mc.HyperVHypervisor != nil && !mc.HyperVHypervisor.UserModeNetworking {
+		return userUserData, nil
+	}
 
-	return userUserData, nil
+	// if user has provided a custom user-data and we are on Hyper-V/user-mode networking,
+	// we need to merge our generated user data with user's one
+	// To do it we create a MIME multi-part archive
+	// with both files
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+
+	// add our configuration as the first part
+	if err := createCloudConfigPart(writer, internalUserDataBytes); err != nil {
+		return nil, fmt.Errorf("failed to create internal cloud-config part: %w", err)
+	}
+
+	// Add the user's config as a second part
+	if err := createCloudConfigPart(writer, userUserData); err != nil {
+		return nil, fmt.Errorf("failed to create user cloud-config part: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// finalize mime archive with top-level header
+	finalContent := new(bytes.Buffer)
+	topLevelHeader := fmt.Sprintf("Content-Type: multipart/mixed; boundary=%s\nMIME-Version: 1.0\n\n", writer.Boundary())
+	finalContent.WriteString(topLevelHeader)
+	finalContent.Write(buf.Bytes())
+
+	return finalContent.Bytes(), nil
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -3,11 +3,9 @@
 package cloudinit
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 
 	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
@@ -69,15 +67,9 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 		}
 	}
 
-	internalUserDataBytes, err := internalUserData.Marshal()
-	if err != nil {
-		logrus.Errorf("Error marshaling to YAML: %v", err)
-		return nil, err
-	}
-
 	// If user has not provided any custom user-data, return the generated one
 	if mc.CloudInitConfig.UserData == nil {
-		return internalUserDataBytes, nil
+		return internalUserData.Marshal()
 	}
 
 	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
@@ -93,30 +85,7 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	// we need to merge our generated user data with user's one
 	// To do it we create a MIME multi-part archive
 	// with both files
-	buf := new(bytes.Buffer)
-	writer := multipart.NewWriter(buf)
-
-	// add our configuration as the first part
-	if err := createCloudConfigPart(writer, internalUserDataBytes); err != nil {
-		return nil, fmt.Errorf("failed to create internal cloud-config part: %w", err)
-	}
-
-	// Add the user's config as a second part
-	if err := createCloudConfigPart(writer, userUserData); err != nil {
-		return nil, fmt.Errorf("failed to create user cloud-config part: %w", err)
-	}
-
-	if err := writer.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
-	// finalize mime archive with top-level header
-	finalContent := new(bytes.Buffer)
-	topLevelHeader := fmt.Sprintf("Content-Type: multipart/mixed; boundary=%s\nMIME-Version: 1.0\n\n", writer.Boundary())
-	finalContent.WriteString(topLevelHeader)
-	finalContent.Write(buf.Bytes())
-
-	return finalContent.Bytes(), nil
+	return internalUserData.MarshalMultiPart(userUserData)
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) error {
@@ -57,7 +56,7 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	// otherwise use the provided one and just add user-mode networking part if needed
 	internalUserData := &UserData{}
 	if mc.CloudInitConfig.UserData == nil {
-		internalUserData, err = getDefaultUserData(mc)
+		internalUserData, err = defaultUserData(mc)
 		if err != nil {
 			return nil, err
 		}
@@ -70,14 +69,11 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 		}
 	}
 
-	internalUserDataBytes, err := yaml.Marshal(internalUserData)
+	internalUserDataBytes, err := internalUserData.Marshal()
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
 		return nil, err
 	}
-
-	headerLine := "#cloud-config\n"
-	internalUserDataBytes = append([]byte(headerLine), internalUserDataBytes...)
 
 	// If user has not provided any custom user-data, return the generated one
 	if mc.CloudInitConfig.UserData == nil {

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -14,7 +14,7 @@ import (
 )
 
 func addUserModeNetworking(userData *UserData, mc *vmconfigs.MachineConfig) error {
-	netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+	netUnitFile, err := hutil.CreateNetworkUnitWithBinary("/usr/local/bin/gvforwarder", mc.HyperVHypervisor.NetworkVSock.Port)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -8,73 +8,87 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/hyperv/hutil"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
-func GenerateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
-	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+func setUserModeNetworkingPart(userData *UserData, mc *vmconfigs.MachineConfig) error {
+	netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	userData := UserData{
-		Users: []User{
-			User{
-				Name:    mc.SSH.RemoteUsername,
-				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
-				Shell:   "/bin/bash",
-				Groups:  []string{"users"},
-				SSHKeys: []string{sshKey},
-			},
+	userData.WriteFiles = []WriteFile{
+		{
+			Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
+			Content:     hutil.HyperVVsockNMConnection,
+			Permissions: "0600",
+			Owner:       "root",
+		},
+		{
+			Path:        "/etc/systemd/system/vsock-network.service",
+			Content:     netUnitFile,
+			Permissions: "0644",
+			Owner:       "root",
 		},
 	}
 
-	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
-		netUnitFile, err := hutil.CreateNetworkUnit(mc.HyperVHypervisor.NetworkVSock.Port)
+	userData.RunCmd = []string{
+		"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
+		"nmcli connection reload",
+		"systemctl daemon-reload",
+		"systemctl enable --now vsock-network.service",
+	}
+
+	userData.Mounts = [][]string{
+		{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},
+	}
+
+	return nil
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	var err error
+	// If user has not provided any custom user-data, generate default
+	// otherwise use the provided one and just add user-mode networking part if needed
+	internalUserData := &UserData{}
+	if mc.CloudInitConfig.UserData == nil {
+		internalUserData, err = getDefaultUserData(mc)
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		userData.WriteFiles = []WriteFile{
-			{
-				Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
-				Content:     hutil.HyperVVsockNMConnection,
-				Permissions: "0600",
-				Owner:       "root",
-			},
-			{
-				Path:        "/etc/systemd/system/vsock-network.service",
-				Content:     netUnitFile,
-				Permissions: "0644",
-				Owner:       "root",
-			},
-		}
-
-		userData.RunCmd = []string{
-			"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
-			"nmcli connection reload",
-			"systemctl daemon-reload",
-			"systemctl enable --now vsock-network.service",
-		}
-
-		userData.Mounts = [][]string{
-			{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},
+	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
+		err = setUserModeNetworkingPart(internalUserData, mc)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	yamlBytes, err := yaml.Marshal(&userData)
+	internalUserDataBytes, err := yaml.Marshal(internalUserData)
 	if err != nil {
 		logrus.Errorf("Error marshaling to YAML: %v", err)
 		return nil, err
 	}
 
 	headerLine := "#cloud-config\n"
-	yamlBytes = append([]byte(headerLine), yamlBytes...)
-	return yamlBytes, nil
+	internalUserDataBytes = append([]byte(headerLine), internalUserDataBytes...)
+
+	// If user has not provided any custom user-data, return the generated one
+	if mc.CloudInitConfig.UserData == nil {
+		return internalUserDataBytes, nil
+	}
+
+	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
+	userUserData, err := mc.CloudInitConfig.UserData.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	return userUserData, nil
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/userdata.go
+++ b/pkg/machine/cloudinit/userdata.go
@@ -1,0 +1,66 @@
+package cloudinit
+
+import (
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+	"gopkg.in/yaml.v3"
+)
+
+type User struct {
+	Name    string   `yaml:"name"`
+	Sudo    string   `yaml:"sudo"`
+	Shell   string   `yaml:"shell"`
+	Groups  []string `yaml:"groups"`
+	SSHKeys []string `yaml:"ssh_authorized_keys"`
+}
+
+type WriteFile struct {
+	Path        string `yaml:"path,omitempty"`
+	Content     string `yaml:"content,omitempty"`
+	Encoding    string `yaml:"encoding,omitempty"`
+	Owner       string `yaml:"owner,omitempty"`
+	Permissions string `yaml:"permissions,omitempty"`
+}
+
+type UserData struct {
+	Users      []User      `yaml:"users"`
+	WriteFiles []WriteFile `yaml:"write_files,omitempty"`
+	RunCmd     []string    `yaml:"runcmd,omitempty"`
+	Mounts     [][]string  `yaml:"mounts,omitempty"`
+}
+
+type EmbeddedResource struct {
+	Name    string `yaml:"name"`
+	Content []byte `yaml:"content"`
+}
+
+func defaultUserData(mc *vmconfigs.MachineConfig) (*UserData, error) {
+	sshKey, err := machine.GetSSHKeys(mc.SSH.IdentityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserData{
+		Users: []User{
+			{
+				Name:    mc.SSH.RemoteUsername,
+				Sudo:    "ALL=(ALL) NOPASSWD:ALL",
+				Shell:   "/bin/bash",
+				Groups:  []string{"users"},
+				SSHKeys: []string{sshKey},
+			},
+		},
+	}, nil
+}
+
+func (userData *UserData) Marshal() ([]byte, error) {
+	data, err := yaml.Marshal(userData)
+	if err != nil {
+		return nil, err
+	}
+
+	headerLine := "#cloud-config\n"
+	data = append([]byte(headerLine), data...)
+
+	return data, nil
+}

--- a/pkg/machine/cloudinit/userdata.go
+++ b/pkg/machine/cloudinit/userdata.go
@@ -1,6 +1,11 @@
 package cloudinit
 
 import (
+	"bytes"
+	"fmt"
+	"mime/multipart"
+	"net/textproto"
+
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"gopkg.in/yaml.v3"
@@ -63,4 +68,52 @@ func (userData *UserData) Marshal() ([]byte, error) {
 	data = append([]byte(headerLine), data...)
 
 	return data, nil
+}
+
+func (userData *UserData) MarshalMultiPart(extraData []byte) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+
+	userDataBytes, err := userData.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall user-data: %w", err)
+	}
+
+	// add our configuration as the first part
+	if err := createCloudConfigPart(writer, userDataBytes); err != nil {
+		return nil, fmt.Errorf("failed to create internal cloud-config part: %w", err)
+	}
+
+	// Add the user's config as a second part
+	if err := createCloudConfigPart(writer, extraData); err != nil {
+		return nil, fmt.Errorf("failed to create user cloud-config part: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// finalize mime archive with top-level header
+	finalContent := new(bytes.Buffer)
+	topLevelHeader := fmt.Sprintf("Content-Type: multipart/mixed; boundary=%s\nMIME-Version: 1.0\n\n", writer.Boundary())
+	finalContent.WriteString(topLevelHeader)
+	finalContent.Write(buf.Bytes())
+
+	return finalContent.Bytes(), nil
+}
+
+func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
+	header := textproto.MIMEHeader{}
+	// Set the specific Content-Type that cloud-init recognizes for configuration files
+	header.Set("Content-Type", "text/cloud-config")
+
+	partWriter, err := writer.CreatePart(header)
+	if err != nil {
+		return fmt.Errorf("failed to create new MIME part: %w", err)
+	}
+
+	if _, err := partWriter.Write(content); err != nil {
+		return fmt.Errorf("failed to write content to MIME part: %w", err)
+	}
+	return nil
 }

--- a/pkg/machine/cloudinit/userdata.go
+++ b/pkg/machine/cloudinit/userdata.go
@@ -106,6 +106,7 @@ func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
 	header := textproto.MIMEHeader{}
 	// Set the specific Content-Type that cloud-init recognizes for configuration files
 	header.Set("Content-Type", "text/cloud-config")
+	header.Set("Merge-Type", "list(append)+dict(no_replace,recurse_list)+str()")
 
 	partWriter, err := writer.CreatePart(header)
 	if err != nil {

--- a/pkg/machine/hyperv/hutil/hutil.go
+++ b/pkg/machine/hyperv/hutil/hutil.go
@@ -6,8 +6,7 @@ import (
 	"github.com/containers/podman/v5/pkg/systemd/parser"
 )
 
-const HyperVVsockNMConnection = `
-[connection]
+const HyperVVsockNMConnection = `[connection]
 id=vsock0
 type=tun
 interface-name=vsock0

--- a/pkg/machine/hyperv/hutil/hutil.go
+++ b/pkg/machine/hyperv/hutil/hutil.go
@@ -23,12 +23,16 @@ method=auto
 [proxy]
 `
 
-func CreateNetworkUnit(netPort uint64) (string, error) {
+func CreateNetworkUnitWithBinary(binaryPath string, netPort uint64) (string, error) {
 	netUnit := parser.NewUnitFile()
 	netUnit.Add("Unit", "Description", "vsock_network")
 	netUnit.Add("Unit", "After", "NetworkManager.service")
-	netUnit.Add("Service", "ExecStart", fmt.Sprintf("/usr/libexec/podman/gvforwarder -preexisting -iface vsock0 -url vsock://2:%d/connect", netPort))
+	netUnit.Add("Service", "ExecStart", fmt.Sprintf("%s -preexisting -iface vsock0 -url vsock://2:%d/connect", binaryPath, netPort))
 	netUnit.Add("Service", "ExecStartPost", "/usr/bin/nmcli c up vsock0")
 	netUnit.Add("Install", "WantedBy", "multi-user.target")
 	return netUnit.ToString()
+}
+
+func CreateNetworkUnit(netPort uint64) (string, error) {
+	return CreateNetworkUnitWithBinary("/usr/libexec/podman/gvforwarder", netPort)
 }


### PR DESCRIPTION
This PR will allow to use --cloud-init and --user-mode-networking simultaneously on hyper-v.
It supersedes https://github.com/cfergeau/podman/pull/36. We could either go with this PR, or add the first 2 commits to #36, and then take this one.
Note: I haven’t tested this yet.


