### PR TITLE
skip reassign SSH port only when on hyperv/system networking

### DIFF
--- a/pkg/machine/shim/networking.go
+++ b/pkg/machine/shim/networking.go
@@ -110,7 +110,9 @@ func startHostForwarder(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvid
 
 func startNetworking(mc *vmconfigs.MachineConfig, provider vmconfigs.VMProvider) (string, machine.APIForwardingState, error) {
 	// Check if SSH port is in use, and reassign if necessary
-	if provider.UserModeNetworkEnabled(mc) && !ports.IsLocalPortAvailable(mc.SSH.Port) {
+	// The specific WSL check covers a known issue with mirrored mode
+	// because the VM shares the same host network stack. (https://github.com/crc-org/macadam/issues/289)
+	if (provider.VMType() == define.WSLVirt || provider.UserModeNetworkEnabled(mc)) && !ports.IsLocalPortAvailable(mc.SSH.Port) {
 		logrus.Warnf("detected port conflict on machine ssh port [%d], reassigning", mc.SSH.Port)
 		if err := reassignSSHPort(mc, provider); err != nil {
 			return "", 0, err


### PR DESCRIPTION
PR https://github.com/cfergeau/podman/pull/19/files introduced a check to only verify/reassign busy ssh port when using user-mode networking.

This was needed for when using hyperv with system networking mode because we set a custom IP/use default ssh port and do not need to verify that port 22 is busy on the host.

However this creates a misbehavior on WSL when using mirrored mode https://github.com/crc-org/macadam/issues/289

This patch just reinforces the local port check to specify the hypervisor we target (hyperv).

All other hypervisors rely on usermode networking, and WSL is a special case.