### PR TITLE
Support file sharing with cloud-init

### DIFF
--- a/pkg/machine/apple/apple.go
+++ b/pkg/machine/apple/apple.go
@@ -380,29 +380,22 @@ func getFirstBootAppleVMIgnition(mc *vmconfigs.MachineConfig) ([]string, error) 
 
 func getFirstBootAppleVMCloudInit(mc *vmconfigs.MachineConfig) ([]string, error) {
 	if mc.LibKrunHypervisor == nil {
-		cloudInitArgs := []string{}
-
-		if mc.CloudInitConfig.UserData != nil {
-			cloudInitArgs = append(cloudInitArgs, mc.CloudInitConfig.UserData.GetPath())
+		// Always call GenerateUserDataFile
+		// if the user provided a custom user-data file, we use it and
+		// add additional data like mounts
+		// otherwise we generate a default user-data file
+		userDataFile, err := cloudinit.GenerateUserDataFile(mc)
+		if err != nil {
+			return nil, err
 		}
+		cloudInitArgs := []string{userDataFile}
 
 		if mc.CloudInitConfig.MetaData != nil {
 			cloudInitArgs = append(cloudInitArgs, mc.CloudInitConfig.MetaData.GetPath())
 		}
-
-		//if user did not pass any mandatory cloud-init files, we generate a default user-data file
-		if len(cloudInitArgs) == 0 {
-			userDataFile, err := cloudinit.GenerateUserDataFile(mc)
-			if err != nil {
-				return nil, err
-			}
-			cloudInitArgs = append(cloudInitArgs, userDataFile)
-		}
-
 		if mc.CloudInitConfig.NetworkConfig != nil {
 			cloudInitArgs = append(cloudInitArgs, mc.CloudInitConfig.NetworkConfig.GetPath())
 		}
-
 		return []string{"--cloud-init", strings.Join(cloudInitArgs, ",")}, nil
 	} else {
 		cloudinitISO, err := cloudinit.GenerateISO(mc)

--- a/pkg/machine/cloudinit/cloudinit_darwin.go
+++ b/pkg/machine/cloudinit/cloudinit_darwin.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package cloudinit
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v5/pkg/machine"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
+)
+
+func addMountsSupport(userData *UserData, mc *vmconfigs.MachineConfig) {
+	userData.Mounts = make([][]string, 0, len(mc.Mounts))
+	for _, m := range mc.Mounts {
+		v := machine.MountToVirtIOFs(m)
+		// cloud-init mounts format:
+		// [fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs-passno]
+		// https://cloudinit.readthedocs.io/en/latest/reference/yaml_examples/mounts.html#mounts
+		opts := fmt.Sprintf("context=%q", machine.NFSSELinuxContext)
+		if v.ReadOnly {
+			opts = opts + ",ro"
+		}
+		entry := []string{v.Tag, v.Target, "virtiofs", opts, "0", "0"}
+		userData.Mounts = append(userData.Mounts, entry)
+	}
+}
+
+func generateDefaultUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	userData, err := defaultUserData(mc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Preserve virtiofs mounts (with options) when using cloud-init
+	if len(mc.Mounts) > 0 {
+		addMountsSupport(userData, mc)
+	}
+
+	return userData.Marshal()
+}
+
+func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
+	// If user has not provided any custom user-data, generate default
+	// otherwise use the provided one
+	if mc.CloudInitConfig.UserData == nil {
+		return generateDefaultUserData(mc)
+	}
+
+	customUserData, err := mc.CloudInitConfig.UserData.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	// if user has provided a custom user-data but there are no mounts, return it as-is
+	if len(mc.Mounts) == 0 {
+		return customUserData, nil
+	}
+
+	// otherwise use the custom user-data and add the user-mode networking configuration or 9p mounts support
+	generatedUserData := &UserData{}
+	addMountsSupport(generatedUserData, mc)
+
+	// if the user has provided a custom user-data
+	// we need to merge our generated user data with the user's one
+	// To do it we create a MIME multi-part archive
+	// with both files
+	return generatedUserData.MarshalMultiPart(customUserData)
+}
+
+func GetEmbeddedResources(_ *vmconfigs.MachineConfig) []EmbeddedResource {
+	return nil
+}

--- a/pkg/machine/cloudinit/cloudinit_linux.go
+++ b/pkg/machine/cloudinit/cloudinit_linux.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package cloudinit
 

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -19,7 +19,7 @@ func addUserModeNetworking(userData *UserData, mc *vmconfigs.MachineConfig) erro
 		return err
 	}
 
-	userData.WriteFiles = []WriteFile{
+	userData.AddWriteFiles([]WriteFile{
 		{
 			Path:        "/etc/NetworkManager/system-connections/vsock0.nmconnection",
 			Content:     hutil.HyperVVsockNMConnection,
@@ -32,14 +32,14 @@ func addUserModeNetworking(userData *UserData, mc *vmconfigs.MachineConfig) erro
 			Permissions: "0644",
 			Owner:       "root",
 		},
-	}
+	})
 
-	userData.RunCmd = []string{
+	userData.AddRunCmds([]string{
 		"install -o root -g root -m 0755 /mnt/gvforwarder /usr/local/bin/gvforwarder",
 		"nmcli connection reload",
 		"systemctl daemon-reload",
 		"systemctl enable --now vsock-network.service",
-	}
+	})
 
 	userData.Mounts = [][]string{
 		{"/dev/sr0", "/mnt", "iso9660", "defaults,ro", "0", "0"},

--- a/pkg/machine/cloudinit/cloudinit_windows.go
+++ b/pkg/machine/cloudinit/cloudinit_windows.go
@@ -48,17 +48,89 @@ func addUserModeNetworking(userData *UserData, mc *vmconfigs.MachineConfig) erro
 	return nil
 }
 
-func defaultHypervUserData(mc *vmconfigs.MachineConfig, userModeNetworking bool) ([]byte, error) {
+func addMountsSupport(userData *UserData, mc *vmconfigs.MachineConfig) error {
+	// Create systemd template service for 9p vsock proxying
+	// Template units use %i as the instance identifier (port number)
+	// This allows us to instantiate one unit per mount without duplication
+	//
+	// We use socat to actively connect to the host's vsock and proxy to a Unix socket.
+	serviceTemplate := `[Unit]
+Description=9p VSOCK to Unix Socket Proxy for port %i
+After=network.target
+
+[Service]
+Type=simple
+# Use socat to actively CONNECT to host's vsock port and create Unix socket
+# VSOCK-CONNECT:2:%i connects to host CID 2 on port %i
+# UNIX-LISTEN:/run/9p-%i.sock creates Unix socket for mount operations
+# Options: -ly enables logging, umask=000 makes socket world-accessible,
+# reuseaddr allows socket reuse, keepalive maintains connection health
+ExecStop=/bin/rm -f /run/9p-%i.sock
+ExecStart=/usr/bin/socat -ly UNIX-LISTEN:/run/9p-%i.sock,umask=000,reuseaddr VSOCK-CONNECT:2:%i,keepalive
+Restart=on-failure
+RestartSec=5
+# Ensure service runs as root (default, but explicit for clarity)
+User=root
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	// Add the template service unit file
+	userData.AddWriteFiles([]WriteFile{
+		WriteFile{
+			Path:        "/etc/systemd/system/9p-vsock@.service",
+			Content:     serviceTemplate,
+			Permissions: "0644",
+			Owner:       "root",
+		},
+	})
+
+	// Add commands to reload systemd and enable the service instances
+	// Ensure /run exists for Unix sockets
+	enableCmds := []string{
+		"mkdir -p /run",
+		"systemctl daemon-reload",
+		"dnf install -y socat",
+	}
+	for _, mount := range mc.Mounts {
+		if mount.VSockNumber != nil {
+			instanceName := fmt.Sprintf("9p-vsock@%d.service", *mount.VSockNumber)
+			enableCmds = append(enableCmds, fmt.Sprintf("systemctl enable --now %s", instanceName))
+		}
+	}
+
+	userData.AddRunCmds(enableCmds)
+
+	return nil
+}
+
+func addAdditionalUserData(userData *UserData, mc *vmconfigs.MachineConfig) error {
+	if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.UserModeNetworking {
+		err := addUserModeNetworking(userData, mc)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(mc.Mounts) > 0 {
+		err := addMountsSupport(userData, mc)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func defaultHypervUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	userData, err := defaultUserData(mc)
 	if err != nil {
 		return nil, err
 	}
 
-	if userModeNetworking {
-		err = addUserModeNetworking(userData, mc)
-		if err != nil {
-			return nil, err
-		}
+	err = addAdditionalUserData(userData, mc)
+	if err != nil {
+		return nil, err
 	}
 
 	return userData.Marshal()
@@ -70,7 +142,7 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 
 	// If user has not provided any custom user-data, generate default
 	if mc.CloudInitConfig.UserData == nil {
-		return defaultHypervUserData(mc, userModeNetworking)
+		return defaultHypervUserData(mc)
 	}
 
 	customUserData, err := mc.CloudInitConfig.UserData.Read()
@@ -78,15 +150,17 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 		return nil, err
 	}
 
-	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking, return it as-is
-	if !userModeNetworking {
+	// if user has provided a custom user-data but we're not on Hyper-V/user-mode networking
+	// and there are no mounts, return it as-is
+	if !userModeNetworking && len(mc.Mounts) == 0 {
 		return customUserData, nil
 	}
 
-	// otherwise use the custom user-data and add the user-mode networking configuration
-	userModeNetworkingUserData := &UserData{}
+	// otherwise use the custom user-data and add the user-mode networking configuration or 9p mounts support
+	generatedUserData := &UserData{}
 
-	if err := addUserModeNetworking(userModeNetworkingUserData, mc); err != nil {
+	err = addAdditionalUserData(generatedUserData, mc)
+	if err != nil {
 		return nil, err
 	}
 
@@ -94,7 +168,7 @@ func generateUserData(mc *vmconfigs.MachineConfig) ([]byte, error) {
 	// we need to merge our generated user data with user's one
 	// To do it we create a MIME multi-part archive
 	// with both files
-	return userModeNetworkingUserData.MarshalMultiPart(customUserData)
+	return generatedUserData.MarshalMultiPart(customUserData)
 }
 
 func getGvForwarderBytes() ([]byte, error) {

--- a/pkg/machine/cloudinit/userdata.go
+++ b/pkg/machine/cloudinit/userdata.go
@@ -118,3 +118,11 @@ func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
 	}
 	return nil
 }
+
+func (userData *UserData) AddRunCmds(runCmds []string) {
+	userData.RunCmd = append(userData.RunCmd, runCmds...)
+}
+
+func (userData *UserData) AddWriteFiles(writeFiles []WriteFile) {
+	userData.WriteFiles = append(userData.WriteFiles, writeFiles...)
+}

--- a/pkg/machine/cloudinit/userdata.go
+++ b/pkg/machine/cloudinit/userdata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mime/multipart"
 	"net/textproto"
+	"slices"
 
 	"github.com/containers/podman/v5/pkg/machine"
 	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
@@ -32,6 +33,7 @@ type UserData struct {
 	WriteFiles []WriteFile `yaml:"write_files,omitempty"`
 	RunCmd     []string    `yaml:"runcmd,omitempty"`
 	Mounts     [][]string  `yaml:"mounts,omitempty"`
+	Packages   []string    `yaml:"packages,omitempty"`
 }
 
 type EmbeddedResource struct {
@@ -117,6 +119,16 @@ func createCloudConfigPart(writer *multipart.Writer, content []byte) error {
 		return fmt.Errorf("failed to write content to MIME part: %w", err)
 	}
 	return nil
+}
+
+func (userData *UserData) AddPackage(packageName string) {
+	if userData.Packages == nil {
+		userData.Packages = []string{packageName}
+	} else {
+		if !slices.Contains(userData.Packages, packageName) {
+			userData.Packages = append(userData.Packages, packageName)
+		}
+	}
 }
 
 func (userData *UserData) AddRunCmds(runCmds []string) {

--- a/pkg/machine/gvproxy.go
+++ b/pkg/machine/gvproxy.go
@@ -25,7 +25,7 @@ func CleanupGVProxy(f define.VMFile) error {
 	if err != nil {
 		return fmt.Errorf("unable to convert pid to integer: %v", err)
 	}
-	if err := waitOnProcess(proxyPid); err != nil {
+	if err := waitOnProcess(proxyPid, "gvproxy"); err != nil {
 		return err
 	}
 	return removeGVProxyPIDFile(f)

--- a/pkg/machine/gvproxy_unix.go
+++ b/pkg/machine/gvproxy_unix.go
@@ -48,8 +48,8 @@ func backoffForProcess(p *psutil.Process) error {
 // / waitOnProcess takes a pid and sends a sigterm to it. it then waits for the
 // process to not exist.  if the sigterm does not end the process after an interval,
 // then sigkill is sent.  it also waits for the process to exit after the sigkill too.
-func waitOnProcess(processID int) error {
-	logrus.Infof("Going to stop gvproxy (PID %d)", processID)
+func waitOnProcess(processID int, processName string) error {
+	logrus.Infof("Going to stop %s (PID %d)", processName, processID)
 
 	p, err := psutil.NewProcess(int32(processID))
 	if err != nil {
@@ -58,7 +58,7 @@ func waitOnProcess(processID int) error {
 
 	running, err := p.IsRunning()
 	if err != nil {
-		return fmt.Errorf("checking if gvproxy is running: %w", err)
+		return fmt.Errorf("checking if %s is running: %w", processName, err)
 	}
 	if !running {
 		return nil
@@ -66,7 +66,7 @@ func waitOnProcess(processID int) error {
 
 	if err := p.Terminate(); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			logrus.Debugf("Gvproxy already dead, exiting cleanly")
+			logrus.Debugf("%s already dead, exiting cleanly", processName)
 			return nil
 		}
 		return err

--- a/pkg/machine/gvproxy_windows.go
+++ b/pkg/machine/gvproxy_windows.go
@@ -2,51 +2,10 @@ package machine
 
 import (
 	"errors"
-	"os"
-	"time"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
-	"github.com/containers/winquit/pkg/winquit"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
-
-func waitOnProcess(processID int) error {
-	logrus.Infof("Going to stop gvproxy (PID %d)", processID)
-
-	p, err := os.FindProcess(processID)
-	if err != nil {
-		// FindProcess on Windows will return an error when the process is not found
-		// if a process can not be found then it has already exited and there is
-		// nothing left to do, so return without error
-		//nolint:nilerr
-		return nil
-	}
-
-	// Gracefully quit and force kill after 30 seconds
-	if err := winquit.QuitProcess(processID, 30*time.Second); err != nil {
-		return err
-	}
-
-	logrus.Debugf("completed grace quit || kill of gvproxy (PID %d)", processID)
-
-	// Make sure the process is gone (Hard kills are async)
-	done := make(chan struct{})
-	go func() {
-		_, _ = p.Wait()
-		done <- struct{}{}
-	}()
-
-	select {
-	case <-done:
-		logrus.Debugf("verified gvproxy termination (PID %d)", processID)
-	case <-time.After(10 * time.Second):
-		// Very unlikely but track just in case
-		logrus.Errorf("was not able to kill gvproxy (PID %d)", processID)
-	}
-
-	return nil
-}
 
 // removeGVProxyPIDFile special wrapper for deleting the GVProxyPIDFile on windows in case
 // the file has an open handle which we will ignore.  unix does not have this problem

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -296,6 +296,15 @@ func (h HyperVStubber) StartVM(mc *vmconfigs.MachineConfig) (func() error, func(
 	}
 	callbackFuncs.Add(startCallback)
 
+	// If we are not using user mode networking, we need to retrieve the VM IP address
+	if !mc.HyperVHypervisor.UserModeNetworking {
+		ip, err := getVMIPAddress(mc.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("retrieving VM's IP: %w", err)
+		}
+		mc.IPAddress = ip
+	}
+
 	return nil, waitReady, err
 }
 
@@ -446,16 +455,6 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, _ bool) 
 	callbackFuncs := machine.CleanUp()
 	defer callbackFuncs.CleanIfErr(&err)
 	go callbackFuncs.CleanOnSignal()
-
-	// If we are not using user mode networking, we need to retrieve the VM IP address
-	if !mc.HyperVHypervisor.UserModeNetworking {
-		ip, err := getVMIPAddress(mc.Name)
-		if err != nil {
-			return fmt.Errorf("retrieving VM's IP: %w", err)
-		}
-		mc.IPAddress = ip
-		return nil
-	}
 
 	if len(mc.Mounts) == 0 {
 		return nil

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -93,15 +93,6 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		hwConfig.Network = true
 	}
 
-	if mc.CloudInit {
-		// Generate cloud-init ISO
-		iso, err := cloudinit.GenerateISO(mc)
-		if err != nil {
-			return fmt.Errorf("generating cloud-init ISO: %w", err)
-		}
-		hwConfig.DVDDiskPath = iso.GetPath()
-	}
-
 	// Add vsock port numbers to mounts
 	err = createShares(mc)
 	if err != nil {
@@ -112,6 +103,17 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		return removeShares(mc)
 	}
 	callbackFuncs.Add(removeShareCallBack)
+
+	// GenerateISO MUST be executed after creating shares to ensure we know the vsock ports
+	// to generate the 9p-vsock@.service unit files for the cloud-init user data file
+	if mc.CloudInit {
+		// Generate cloud-init ISO
+		iso, err := cloudinit.GenerateISO(mc)
+		if err != nil {
+			return fmt.Errorf("generating cloud-init ISO: %w", err)
+		}
+		hwConfig.DVDDiskPath = iso.GetPath()
+	}
 
 	removeRegistrySockets := func() error {
 		removeNetworkAndReadySocketsFromRegistry(mc)
@@ -334,9 +336,24 @@ func (h HyperVStubber) StopVM(mc *vmconfigs.MachineConfig, hardStop bool) error 
 	}
 
 	if hardStop {
-		return vm.StopWithForce()
+		err = vm.StopWithForce()
+	} else {
+		err = vm.Stop()
 	}
-	return vm.Stop()
+	if err != nil {
+		return err
+	}
+
+	// Stop the 9p server if it's running
+	dirs, err := env.GetMachineDirs(h.VMType())
+	if err != nil {
+		return err
+	}
+	err = machine.StopServer9p(mc, dirs)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // TODO should this be plumbed higher into the code stack?
@@ -468,14 +485,19 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, _ bool) 
 	if err != nil {
 		return err
 	}
-	// GvProxy PID file path is now derived
-	gvproxyPIDFile, err := machine.GetGVProxyPIDFile(mc, dirs)
-	if err != nil {
-		return err
-	}
-	gvproxyPID, err = gvproxyPIDFile.ReadPIDFrom()
-	if err != nil {
-		return err
+	// If user mode networking is enabled, we need to get the GvProxy PID
+	// to pass to the 9p server.
+	// If cloud-init is enabled, we do not need to pass the GvProxy PID to the 9p server.
+	if !mc.CloudInit && mc.HyperVHypervisor.UserModeNetworking {
+		// GvProxy PID file path is now derived
+		gvproxyPIDFile, err := machine.GetGVProxyPIDFile(mc, dirs)
+		if err != nil {
+			return err
+		}
+		gvproxyPID, err = gvproxyPIDFile.ReadPIDFrom()
+		if err != nil {
+			return err
+		}
 	}
 
 	executable, err = os.Executable()
@@ -495,14 +517,16 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, _ bool) 
 		}
 		p9ServerArgs = append(p9ServerArgs, "--serve", fmt.Sprintf("%s:%s", mount.Source, winio.VsockServiceID(uint32(*mount.VSockNumber)).String()))
 	}
-	p9ServerArgs = append(p9ServerArgs, fmt.Sprintf("%d", gvproxyPID))
+	if gvproxyPID > 0 {
+		p9ServerArgs = append(p9ServerArgs, fmt.Sprintf("%d", gvproxyPID))
+	}
 
 	logrus.Debugf("Going to start 9p server using command: %s %v", executable, p9ServerArgs)
 
 	fsCmd := exec.Command(executable, p9ServerArgs...)
 
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		log, err := logCommandToFile(fsCmd, "podman-machine-server9.log")
+		log, err := logCommandToFile(fsCmd, fmt.Sprintf("machine-server9p-%s.log", mc.Name))
 		if err != nil {
 			return err
 		}
@@ -513,10 +537,29 @@ func (h HyperVStubber) PostStartNetworking(mc *vmconfigs.MachineConfig, _ bool) 
 	if err != nil {
 		return fmt.Errorf("unable to start 9p server: %v", err)
 	}
-	logrus.Infof("Started podman 9p server as PID %d", fsCmd.Process.Pid)
+	server9pPID := fsCmd.Process.Pid
+	logrus.Infof("Started 9p server as PID %d", server9pPID)
 
-	// Note: No callback is needed to stop the 9p server, because it will stop when
-	// gvproxy stops
+	// Note: To keep compatibility with upstream podman, when using ignition, no callback is needed to stop the 9p server, because it will stop when
+	// gvproxy stops. When using cloud-init, we need to store the PID file to clean up on VM stop.
+	if mc.CloudInit {
+		// Store the PID file for cleanup on stop
+		serverPIDFile, err := machine.GetServer9pPIDFile(mc, dirs)
+		if err != nil {
+			return fmt.Errorf("unable to get server9p PID file: %w", err)
+		}
+		if err := os.WriteFile(serverPIDFile.GetPath(), []byte(fmt.Sprintf("%d", server9pPID)), 0o644); err != nil {
+			return fmt.Errorf("unable to write server9p PID file: %w", err)
+		}
+		// Add cleanup callback to remove PID file if startShares fails or on error
+		cleanupPIDFile := func() error {
+			if err := serverPIDFile.Delete(); err != nil {
+				logrus.Warnf("Failed to clean up server9p PID file: %v", err)
+			}
+			return nil
+		}
+		callbackFuncs.Add(cleanupPIDFile)
+	}
 
 	// Finalize starting shares after we are confident gvproxy is still alive.
 	err = startShares(mc)

--- a/pkg/machine/hyperv/volumes.go
+++ b/pkg/machine/hyperv/volumes.go
@@ -54,17 +54,29 @@ func startShares(mc *vmconfigs.MachineConfig) error {
 			args = append(args, "sudo", "chattr", "+i", "/", "; ")
 		}
 
-		args = append(args, "sudo", "podman")
-		if logrus.IsLevelEnabled(logrus.DebugLevel) {
-			args = append(args, "--log-level=debug")
-		}
 		// just being protective here; in a perfect world, this cannot happen
 		if mount.VSockNumber == nil {
 			return errors.New("cannot start 9p shares with undefined vsock number")
 		}
-		args = append(args, "machine", "client9p", fmt.Sprintf("%d", *mount.VSockNumber), strconv.Quote(mount.Target))
 
-		if err := machine.LocalhostSSH(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.SSH.Port, args); err != nil {
+		if mc.CloudInit {
+			// Mount using Unix socket created by systemd
+			// The systemd service proxies vsock to /run/9p-<port>.sock
+			unixSocketPath := fmt.Sprintf("/run/9p-%d.sock", *mount.VSockNumber)
+			quotedTarget := strconv.Quote(cleanTarget)
+			// Wait for socket with timeout (120 seconds max, checking every 0.4s = 300 iterations)
+			mountScript := fmt.Sprintf(`i=0; while [ ! -S %s ] && [ $i -lt 300 ]; do sleep 0.4; i=$((i+1)); done; [ -S %s ] || { echo "Timeout"; exit 1; }; sleep 2; mount -t 9p -o trans=unix,version=9p2000.L %s %s`, unixSocketPath, unixSocketPath, unixSocketPath, quotedTarget)
+			// Quote the entire script so it survives strings.Join in the SSH function
+			args = append(args, "sudo", "sh", "-c", fmt.Sprintf("'%s'", mountScript))
+		} else {
+			args = append(args, "sudo", "podman")
+			if logrus.IsLevelEnabled(logrus.DebugLevel) {
+				args = append(args, "--log-level=debug")
+			}
+			args = append(args, "machine", "client9p", fmt.Sprintf("%d", *mount.VSockNumber), strconv.Quote(mount.Target))
+		}
+
+		if err := machine.LocalhostSSHWithAddress(mc.SSH.RemoteUsername, mc.SSH.IdentityPath, mc.Name, mc.IPAddress, mc.SSH.Port, args); err != nil {
 			return err
 		}
 	}

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/sockets"
+	"github.com/containers/podman/v5/pkg/machine/vmconfigs"
 	"github.com/containers/winquit/pkg/winquit"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
@@ -284,6 +285,42 @@ func GetWinProxyStateDir(name string, vmtype define.VMType) (string, error) {
 
 func GetEnvSetString(env string, val string) string {
 	return fmt.Sprintf("$Env:%s=\"%s\"", env, val)
+}
+
+func GetServer9pPIDFile(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) (*define.VMFile, error) {
+	return dirs.RuntimeDir.AppendToNewVMFile(fmt.Sprintf("server9p-%s.pid", mc.Name), nil)
+}
+
+func StopServer9p(mc *vmconfigs.MachineConfig, dirs *define.MachineDirs) error {
+	pidFile, err := GetServer9pPIDFile(mc, dirs)
+	if err != nil {
+		return err
+	}
+	pid, err := pidFile.ReadPIDFrom()
+	if err != nil {
+		// PID file doesn't exist or is invalid - server might not be running
+		logrus.Debugf("Server9p PID file not found or invalid (server may not be running): %v", err)
+		return nil
+	}
+
+	// Validate PID is positive before attempting to stop
+	if pid <= 0 {
+		logrus.Warnf("Invalid PID %d from server9p PID file, skipping stop", pid)
+		// Clean up invalid PID file
+		if err := pidFile.Delete(); err != nil {
+			logrus.Warnf("Failed to clean up invalid server9p PID file: %v", err)
+		}
+		return nil
+	}
+
+	if err = waitOnProcess(pid, "server9p"); err != nil {
+		return err
+	}
+
+	if err := pidFile.Delete(); err != nil {
+		logrus.Warnf("Failed to clean up server9p PID file: %v", err)
+	}
+	return nil
 }
 
 func waitOnProcess(processID int, processName string) error {

--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/podman/v5/pkg/machine/define"
 	"github.com/containers/podman/v5/pkg/machine/env"
 	"github.com/containers/podman/v5/pkg/machine/sockets"
+	"github.com/containers/winquit/pkg/winquit"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/storage/pkg/fileutils"
@@ -283,4 +284,41 @@ func GetWinProxyStateDir(name string, vmtype define.VMType) (string, error) {
 
 func GetEnvSetString(env string, val string) string {
 	return fmt.Sprintf("$Env:%s=\"%s\"", env, val)
+}
+
+func waitOnProcess(processID int, processName string) error {
+	logrus.Infof("Going to stop %s (PID %d)", processName, processID)
+
+	p, err := os.FindProcess(processID)
+	if err != nil {
+		// FindProcess on Windows will return an error when the process is not found
+		// if a process can not be found then it has already exited and there is
+		// nothing left to do, so return without error
+		//nolint:nilerr
+		return nil
+	}
+
+	// Gracefully quit and force kill after 30 seconds
+	if err := winquit.QuitProcess(processID, 30*time.Second); err != nil {
+		return err
+	}
+
+	logrus.Debugf("completed grace quit || kill of %s (PID %d)", processName, processID)
+
+	// Make sure the process is gone (Hard kills are async)
+	done := make(chan struct{})
+	go func() {
+		_, _ = p.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+		logrus.Debugf("verified %s termination (PID %d)", processName, processID)
+	case <-time.After(10 * time.Second):
+		// Very unlikely but track just in case
+		logrus.Errorf("was not able to kill %s (PID %d)", processName, processID)
+	}
+
+	return nil
 }

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -581,11 +581,6 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 		machine.PrintRootlessWarning(mc.Name)
 	}
 
-	err = mp.PostStartNetworking(mc, opts.NoInfo)
-	if err != nil {
-		return err
-	}
-
 	stateF := func() (machineDefine.Status, error) {
 		return mp.State(mc, true)
 	}
@@ -601,6 +596,12 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, dirs *machineDe
 			return fmt.Errorf("%s: ssh error: %v", msg, sshError)
 		}
 		return errors.New(msg)
+	}
+
+	// Start networking after VM readiness check to ensure SSH is working
+	err = mp.PostStartNetworking(mc, opts.NoInfo)
+	if err != nil {
+		return err
 	}
 
 	// now that the machine has transitioned into the running state, we don't need a goroutine listening for SIGINT or SIGTERM to handle state

--- a/pkg/machine/ssh.go
+++ b/pkg/machine/ssh.go
@@ -20,6 +20,13 @@ func LocalhostSSH(username, identityPath, name string, sshPort int, inputArgs []
 	return localhostBuiltinSSH(username, identityPath, name, "localhost", sshPort, inputArgs, true, os.Stdin)
 }
 
+func LocalhostSSHWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
+	if address == "" {
+		address = "localhost"
+	}
+	return localhostBuiltinSSH(username, identityPath, name, address, sshPort, inputArgs, true, os.Stdin)
+}
+
 // This ssh’es to a podman machine which is not listening on localhost but has its own IP
 func LocalhostSSHShellWithAddress(username, identityPath, name, address string, sshPort int, inputArgs []string) error {
 	if address == "" {


### PR DESCRIPTION
Implements file sharing with cloud-init.

On macOS the virtio mounts are added into the user-data using the Mounts field.
On linux it should work without any modifications.
On WSL it's not needed to support file sharing as the C drive is already available. 
On hyperv it uses a similar mechanism as podman. The server9p command is
executed which starts listening on a vsock port for each mount.

On the guest side podman client9p is replaced by a systemd service (9p-vsock@.service) that proxies vsock connection to Unix socket for each mount. To proxy the connection it leverages socat which is installed via cloud-init.
The socket is then mounted by executing mount -t 9p ... through ssh.

It supports both user-mode and system networking. For this reason, we do not expect the server9p to be shut down when gvproxy stops running but the server is stopped gracefully when the VM gets stopped.

