### PR TITLE
Refactor Hyper-V HVSock Port Allocation and Decouple Tool Name Hardcoding

### DIFF
--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -13,7 +13,7 @@ import (
 	"go.podman.io/storage/pkg/homedir"
 )
 
-var getToolName = sync.OnceValue(func() string {
+var GetToolName = sync.OnceValue(func() string {
 	toolName := os.Getenv("PODMAN_TOOL_PREFIX")
 	if toolName == "" {
 		toolName = "podman"
@@ -162,7 +162,7 @@ func GetSSHIdentityPath(name string) (string, error) {
 }
 
 func WithToolPrefix(name string) string {
-	toolName := getToolName()
+	toolName := GetToolName()
 	if !strings.HasPrefix(name, toolName) {
 		name = fmt.Sprintf("%s-%s", toolName, name)
 	}

--- a/pkg/machine/env/dir.go
+++ b/pkg/machine/env/dir.go
@@ -48,16 +48,21 @@ func GetGlobalDataDir() (string, error) {
 }
 
 func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
-	rtDir, err := getRuntimeDir()
-	if err != nil {
-		return nil, err
-	}
-
 	// The runtime directory can be customized using the PODMAN_RUNTIME_DIR env variable
-	// Its default value will be podman
+	// Its default value will be podman and be used as <xdgDataHome>/containers/podman
 	// When used by macadam it can be customized to use a different path like macadam
+	// if it is an absolute path, it is used directly
 	runtimeDir := GetRuntimeDirSuffix()
-	rtDir = filepath.Join(rtDir, runtimeDir)
+	var rtDir string
+	if filepath.IsAbs(runtimeDir) {
+		rtDir = runtimeDir
+	} else {
+		base, err := getRuntimeDir()
+		if err != nil {
+			return nil, err
+		}
+		rtDir = filepath.Join(base, runtimeDir)
+	}
 	configDir, err := GetConfDir(vmType)
 	if err != nil {
 		return nil, err
@@ -109,16 +114,21 @@ func GetMachineDirs(vmType define.VMType) (*define.MachineDirs, error) {
 	return &dirs, err
 }
 
-// DataDirPrefix returns the path prefix for all machine data files
-// The config directory can be customized using the PODMAN_DATA_DIR env variable
-// Its default value will be /podman/machine
-// When used by macadam it can be customized to use a different path like /macadam/machine
+// DataDirPrefix returns the path prefix for all machine data files.
+// The directory can be customized using the PODMAN_DATA_DIR env variable.
+// When PODMAN_DATA_DIR is a relative path (default: "podman/machine"), it is
+// joined as <xdgDataHome>/containers/<PODMAN_DATA_DIR>.
+// When PODMAN_DATA_DIR is an absolute path, it is used directly, allowing
+// third-party applications to place data anywhere (e.g. ~/.crc/machine).
 func DataDirPrefix() (string, error) {
+	machineDataDir := getDataDirSuffix()
+	if filepath.IsAbs(machineDataDir) {
+		return machineDataDir, nil
+	}
 	data, err := homedir.GetDataHome()
 	if err != nil {
 		return "", err
 	}
-	machineDataDir := getDataDirSuffix()
 	dataDir := filepath.Join(data, "containers", machineDataDir)
 	return dataDir, nil
 }
@@ -138,16 +148,18 @@ func GetConfDir(vmType define.VMType) (string, error) {
 	return confDir, mkdirErr
 }
 
-// ConfDirPrefix returns the path prefix for all machine config files
-// The config directory can be customized using the PODMAN_DATA_DIR env variable
-// Its default value will be /podman/machine
-// When used by macadam it can be customized to use a different path like /macadam/machine
+// ConfDirPrefix returns the path prefix for all machine config files.
+// It follows the same absolute/relative logic as DataDirPrefix: when
+// PODMAN_DATA_DIR is absolute, that path is used directly.
 func ConfDirPrefix() (string, error) {
+	machineDataDir := getDataDirSuffix()
+	if filepath.IsAbs(machineDataDir) {
+		return machineDataDir, nil
+	}
 	conf, err := homedir.GetConfigHome()
 	if err != nil {
 		return "", err
 	}
-	machineDataDir := getDataDirSuffix()
 	confDir := filepath.Join(conf, "containers", machineDataDir)
 	return confDir, nil
 }

--- a/pkg/machine/hyperv/hutil.go
+++ b/pkg/machine/hyperv/hutil.go
@@ -9,17 +9,17 @@ import (
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
+	"go.podman.io/podman/v6/pkg/machine/env"
 	"go.podman.io/podman/v6/pkg/machine/windows"
 	syswindows "golang.org/x/sys/windows"
 )
 
 var (
-	ErrHypervUserNotInAdminGroup             = errors.New("Hyper-V machines require Hyper-V admin rights to be managed. Please add the current user to the Hyper-V Administrators group or run Podman as an administrator")
-	ErrHypervRegistryInitRequiresElevation   = errors.New("the first time Podman initializes a Hyper-V machine, it requires admin rights. Please run Podman as an administrator")
-	ErrHypervRegistryRemoveRequiresElevation = errors.New("removing this Hyper-V machine requires admin rights to clean up the Windows Registry. Please run Podman as an administrator")
-	ErrHypervRegistryUpdateRequiresElevation = errors.New("this machine's configuration requires additional Hyper-V networking (hvsock) entries in the Windows Registry. Please run Podman as an administrator")
-	ErrHypervLegacyMachineRequiresElevation  = errors.New("starting or stopping Hyper-V machines created with Podman 5.x or earlier requires admin rights. Please run Podman as an administrator")
-	ErrHypervPrepareHostForHyperV            = errors.New("podman needs to prepare the host to run Hyper-V machines without requiring Administrator rights in the future. This involves a one-time setup of the Windows Registry and adding your account to the 'Hyper-V Administrators' group")
+	ErrHypervUserNotInAdminGroup             = errors.New("Hyper-V machines require Hyper-V admin rights to be managed. Please add the current user to the Hyper-V Administrators group or run the command as an administrator")
+	ErrHypervRegistryInitRequiresElevation   = errors.New("the first time Podman initializes a Hyper-V machine, it requires admin rights. Please run the command as an administrator")
+	ErrHypervRegistryRemoveRequiresElevation = errors.New("removing this Hyper-V machine requires admin rights to clean up the Windows Registry. Please run the command as an administrator")
+	ErrHypervRegistryUpdateRequiresElevation = errors.New("insufficient HVSock registry entries for this VM. Run this command as Administrator or execute 'system hyperv-prep' to pre-allocate entries.")
+	ErrHypervLegacyMachineRequiresElevation  = errors.New("starting or stopping Hyper-V machines created with Podman 5.x or earlier requires admin rights. Please run the command as an administrator")
 
 	// Lazily load the NetAPI32 DLL and the function we need
 	modnetapi32                 = syswindows.NewLazySystemDLL("netapi32.dll")
@@ -28,6 +28,14 @@ var (
 	procNetLocalGroupGetMembers = modnetapi32.NewProc("NetLocalGroupGetMembers")
 	procNetApiBufferFree        = modnetapi32.NewProc("NetApiBufferFree")
 )
+
+// ErrHypervPrepareHostForHyperV returns an error describing the one-time host
+// setup needed for Hyper-V machines. The tool name is resolved at call time so
+// it reflects the actual binary (e.g. "macadam", "podman") instead of being
+// hardcoded.
+func ErrHypervPrepareHostForHyperV() error {
+	return fmt.Errorf("%s needs to prepare the host to run Hyper-V machines without requiring Administrator rights in the future. This involves a one-time setup of the Windows Registry and adding your account to the 'Hyper-V Administrators' group", env.GetToolName())
+}
 
 type localGroupMembersInfo0 struct {
 	Sid *syswindows.SID

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -43,7 +43,7 @@ type HyperVStubber struct {
 type permissionChecks struct {
 	isElevatedProcess   func() bool
 	isHyperVAdminMember func() bool
-	vsockEntriesExist   func(int, map[uint64]bool) bool
+	vsockEntriesExist   func(int, int, map[uint64]bool) bool
 	existingMachinesNum func() (int, error)
 }
 
@@ -103,7 +103,11 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	//
 	// This is to prevent to prevent an error for trying to create a vsock entry
 	// in the Windows registry if the user doesn't have the privileges.
-	if err := h.canCreate(len(mc.Mounts), excludePorts); err != nil {
+	eventsNum := 1
+	if mc.CloudInit {
+		eventsNum = 0
+	}
+	if err := h.canCreate(len(mc.Mounts), eventsNum, excludePorts); err != nil {
 		// If it returns ErrHypervRegistryUpdateRequiresElevation and we're not already re-executing,
 		// offer to elevate automatically if user is in admin group
 		if errors.Is(err, ErrHypervRegistryUpdateRequiresElevation) &&
@@ -351,20 +355,24 @@ func (h HyperVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() err
 // The `mounts` parameter is the number of Mounts of the machine. A
 // specific Windows registry entry is necessary for every single mount.
 //
+// The `events` parameter is the number of Events (ready) vsock entries
+// required. Pass 0 to skip the Events check (e.g. for cloud-init VMs
+// that do not use the ready vsock).
+//
 // It returns `ErrHypervRegistryUpdateRequiresElevation` if the vsock
 // entries in the Windows registry don't exist.
 //
 // It returns `ErrHypervUserNotInAdminGroup` if the user doesn't
 // belong to the Hyper-V administrators group.
-func (h HyperVStubber) canCreate(mounts int, excludePorts map[uint64]bool) error {
-	return checkCanCreate(h.defaultPermissionChecks(), mounts, excludePorts)
+func (h HyperVStubber) canCreate(mounts, events int, excludePorts map[uint64]bool) error {
+	return checkCanCreate(h.defaultPermissionChecks(), mounts, events, excludePorts)
 }
 
-func checkCanCreate(checks permissionChecks, mounts int, excludePorts map[uint64]bool) error {
+func checkCanCreate(checks permissionChecks, mounts, events int, excludePorts map[uint64]bool) error {
 	if checks.isElevatedProcess() {
 		return nil
 	}
-	if !checks.vsockEntriesExist(mounts, excludePorts) {
+	if !checks.vsockEntriesExist(mounts, events, excludePorts) {
 		return ErrHypervRegistryUpdateRequiresElevation
 	}
 	if !checks.isHyperVAdminMember() {

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -15,6 +15,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/Microsoft/go-winio"
 	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
@@ -41,7 +43,7 @@ type HyperVStubber struct {
 type permissionChecks struct {
 	isElevatedProcess   func() bool
 	isHyperVAdminMember func() bool
-	vsockEntriesExist   func(int) bool
+	vsockEntriesExist   func(int, map[uint64]bool) bool
 	existingMachinesNum func() (int, error)
 }
 
@@ -88,6 +90,12 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		Memory:   uint64(mc.Resources.Memory),
 	}
 
+	// Collect ports already claimed by other machines so this VM picks
+	// unique ports. The guest has ports hardcoded in ignition/cloud-init so we must
+	// ensure the new machine picks a port that no other machine has baked into its guest.
+	// Otherwise the user could not start them in parallel.W
+	excludePorts := h.portsClaimedByOtherMachines(mc.Name)
+
 	// Allow creation in these two cases:
 	// 1. if the user is Admin
 	// 2. if the user has Hyper-V admin rights and a vsock registry entry exists
@@ -95,13 +103,13 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	//
 	// This is to prevent to prevent an error for trying to create a vsock entry
 	// in the Windows registry if the user doesn't have the privileges.
-	if err := h.canCreate(len(mc.Mounts)); err != nil {
-		// If it returns ErrHypervRegistryInitRequiresElevation and we're not already re-executing,
+	if err := h.canCreate(len(mc.Mounts), excludePorts); err != nil {
+		// If it returns ErrHypervRegistryUpdateRequiresElevation and we're not already re-executing,
 		// offer to elevate automatically if user is in admin group
-		if errors.Is(err, ErrHypervRegistryInitRequiresElevation) &&
+		if errors.Is(err, ErrHypervRegistryUpdateRequiresElevation) &&
 			!windows.IsReExecuting() &&
 			windows.IsInAdministratorsGroup() {
-			message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV.Error(), windows.UACConfirmationPrompt)
+			message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV().Error(), windows.UACConfirmationPrompt)
 			return launchElevate(message)
 		}
 		return err
@@ -150,7 +158,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 				return nil
 			}
 
-			if err := vsock.RemoveAllHVSockRegistryEntries(); err != nil {
+			if err := vsock.RemoveAllHVSockRegistryEntries(false); err != nil {
 				return fmt.Errorf("unable to remove hvsock registry entries: %q", err)
 			}
 
@@ -161,10 +169,10 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 		// Attempt to load an existing HVSock registry entry for networking.
 		// If no existing entry is found, create a new one.
 		// Creating a new entry requires administrative rights.
-		networkHVSock, err := vsock.LoadHVSockRegistryEntryByPurpose(vsock.Network)
+		networkHVSock, err := vsock.GetAvailableHVSock(vsock.Network, excludePorts)
 		if err != nil {
 			if !windows.HasAdminRights() {
-				return ErrHypervRegistryInitRequiresElevation
+				return ErrHypervRegistryUpdateRequiresElevation
 			}
 			networkHVSock, err = vsock.NewHVSockRegistryEntry(vsock.Network, false)
 			if err != nil {
@@ -179,7 +187,7 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	}
 
 	// Add vsock port numbers to mounts
-	err = createShares(mc)
+	err = createShares(mc, excludePorts)
 	if err != nil {
 		return err
 	}
@@ -343,21 +351,21 @@ func (h HyperVStubber) Remove(mc *vmconfigs.MachineConfig) ([]string, func() err
 // The `mounts` parameter is the number of Mounts of the machine. A
 // specific Windows registry entry is necessary for every single mount.
 //
-// It returns `ErrHypervRegistryInitRequiresElevation` if the vsock
+// It returns `ErrHypervRegistryUpdateRequiresElevation` if the vsock
 // entries in the Windows registry don't exist.
 //
 // It returns `ErrHypervUserNotInAdminGroup` if the user doesn't
 // belong to the Hyper-V administrators group.
-func (h HyperVStubber) canCreate(mounts int) error {
-	return checkCanCreate(h.defaultPermissionChecks(), mounts)
+func (h HyperVStubber) canCreate(mounts int, excludePorts map[uint64]bool) error {
+	return checkCanCreate(h.defaultPermissionChecks(), mounts, excludePorts)
 }
 
-func checkCanCreate(checks permissionChecks, mounts int) error {
+func checkCanCreate(checks permissionChecks, mounts int, excludePorts map[uint64]bool) error {
 	if checks.isElevatedProcess() {
 		return nil
 	}
-	if !checks.vsockEntriesExist(mounts) {
-		return ErrHypervRegistryInitRequiresElevation
+	if !checks.vsockEntriesExist(mounts, excludePorts) {
+		return ErrHypervRegistryUpdateRequiresElevation
 	}
 	if !checks.isHyperVAdminMember() {
 		return ErrHypervUserNotInAdminGroup
@@ -368,7 +376,10 @@ func checkCanCreate(checks permissionChecks, mounts int) error {
 // launchElevate attempts to automatically re-run the command as administrator
 // This is similar to how WSL handles elevation.
 func launchElevate(message string) error {
-	if windows.MessageBox(message, "Podman Machine", false) != 1 {
+	toolName := env.GetToolName()
+	r, size := utf8.DecodeRuneInString(toolName)
+	title := fmt.Sprintf("%s Machine", string(unicode.ToUpper(r))+toolName[size:]) //nolint:staticcheck
+	if windows.MessageBox(message, title, false) != 1 {
 		return errors.New("elevation process cancelled by user. Please rerun the command as administrator")
 	}
 	err := windows.CreateOrTruncateElevatedOutputFile()
@@ -439,8 +450,8 @@ func canSkipVSockEntriesRemoval(machines int, hv vmconfigs.HyperVConfig) bool {
 	if machines > 1 {
 		return true
 	}
-	if !hv.NetworkVSock.KeepAfterMachineRemove ||
-		!hv.ReadyVsock.KeepAfterMachineRemove {
+	if (hv.NetworkVSock.KeyName != "" && !hv.NetworkVSock.KeepAfterMachineRemove) ||
+		(hv.ReadyVsock.KeyName != "" && !hv.ReadyVsock.KeepAfterMachineRemove) {
 		return false
 	}
 	for _, m := range hv.FileserverVSocks {
@@ -470,7 +481,42 @@ func (h HyperVStubber) canStartOrStop(mc *vmconfigs.MachineConfig) error {
 	return nil
 }
 
-// countMachinesWithToolname counts only machines that have a toolname field with value "podman".
+// portsClaimedByOtherMachines collects all vsock ports that are already
+// referenced by other machines' configurations. This is used at VM creation
+// time to ensure the new machine picks a port that no other machine has baked
+// into its guest ignition/cloud-init.
+func (h HyperVStubber) portsClaimedByOtherMachines(currentMachineName string) map[uint64]bool {
+	ports := make(map[uint64]bool)
+	dirs, err := env.GetMachineDirs(h.VMType())
+	if err != nil {
+		logrus.Debugf("could not get machine dirs: %v", err)
+		return ports
+	}
+	mcs, err := vmconfigs.LoadMachinesInDir(dirs)
+	if err != nil {
+		logrus.Debugf("could not load existing machines: %v", err)
+		return ports
+	}
+	for name, mc := range mcs {
+		if name == currentMachineName || mc.HyperVHypervisor == nil {
+			continue
+		}
+		if mc.HyperVHypervisor.ReadyVsock.Port != 0 {
+			ports[mc.HyperVHypervisor.ReadyVsock.Port] = true
+		}
+		if mc.HyperVHypervisor.NetworkVSock.Port != 0 {
+			ports[mc.HyperVHypervisor.NetworkVSock.Port] = true
+		}
+		for _, fs := range mc.HyperVHypervisor.FileserverVSocks {
+			if fs.Port != 0 {
+				ports[fs.Port] = true
+			}
+		}
+	}
+	return ports
+}
+
+// countMachinesWithToolname counts machines whose ReadyVsock.ToolName matches the current tool name.
 func (h HyperVStubber) countMachinesWithToolname() (int, error) {
 	dirs, err := env.GetMachineDirs(h.VMType())
 	if err != nil {
@@ -480,9 +526,10 @@ func (h HyperVStubber) countMachinesWithToolname() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	toolName := env.GetToolName()
 	count := 0
 	for _, mc := range mcs {
-		if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.ReadyVsock.ToolName == "podman" {
+		if mc.HyperVHypervisor != nil && mc.HyperVHypervisor.ReadyVsock.ToolName == toolName {
 			count++
 		}
 	}
@@ -537,7 +584,7 @@ func (h HyperVStubber) removeHvSockFromRegistry() error {
 	if machines > 1 {
 		return nil
 	}
-	return vsock.RemoveAllHVSockRegistryEntries()
+	return vsock.RemoveAllHVSockRegistryEntries(false)
 }
 
 func (h HyperVStubber) RemoveAndCleanMachines(_ *define.MachineDirs) error {
@@ -783,7 +830,7 @@ func (h HyperVStubber) PrepareIgnition(mc *vmconfigs.MachineConfig, _ *ignition.
 	if err != nil {
 		if !windows.HasAdminRights() {
 			if !windows.IsReExecuting() && windows.IsInAdministratorsGroup() {
-				message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV.Error(), windows.UACConfirmationPrompt)
+				message := fmt.Sprintf("%s.\n\n%s", ErrHypervPrepareHostForHyperV().Error(), windows.UACConfirmationPrompt)
 				return nil, launchElevate(message)
 			}
 			return nil, ErrHypervRegistryInitRequiresElevation

--- a/pkg/machine/hyperv/volumes.go
+++ b/pkg/machine/hyperv/volumes.go
@@ -62,11 +62,14 @@ func startShares(mc *vmconfigs.MachineConfig) error {
 	return nil
 }
 
-func createShares(mc *vmconfigs.MachineConfig) (err error) {
-	fileServerVsocks, err := vsock.LoadAllHVSockRegistryEntriesByPurpose(vsock.Fileserver)
+func createShares(mc *vmconfigs.MachineConfig, excludePorts map[uint64]bool) (err error) {
+	// Find an available fileserver vsock entry not already claimed by
+	// another machine.
+	fileServerVsocks, err := vsock.ListAvailableHVSocks(vsock.Fileserver, excludePorts)
 	if err != nil {
 		return fmt.Errorf("failed to load existing file server vsock registry entries: %w", err)
 	}
+
 	for i, mount := range mc.Mounts {
 		var testVsock *vsock.HVSockRegistryEntry
 
@@ -77,9 +80,6 @@ func createShares(mc *vmconfigs.MachineConfig) (err error) {
 			// If no existing vsock entry can be reused, a new one must be created.
 			// Creating a new HVSockRegistryEntry requires administrator privileges.
 			if !windows.HasAdminRights() {
-				if i == 0 {
-					return ErrHypervRegistryInitRequiresElevation
-				}
 				return ErrHypervRegistryUpdateRequiresElevation
 			}
 			testVsock, err = vsock.NewHVSockRegistryEntry(vsock.Fileserver, false)

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -420,15 +420,18 @@ func loadHVSockRegistryEntries(purpose HVSockPurpose, limit int) ([]*HVSockRegis
 	return allEntries, nil
 }
 
-func CheckIfHVSockRegistryEntriesExist(mountsNum int, excludePorts map[uint64]bool) bool {
+func CheckIfHVSockRegistryEntriesExist(mountsNum, eventsNum int, excludePorts map[uint64]bool) bool {
 	// The number or required HVSock registry entries
 	// depends on the purpose
 	requiredEntries := map[HVSockPurpose]int{
 		Network:    1,
-		Events:     1,
+		Events:     eventsNum,
 		Fileserver: mountsNum,
 	}
 	for p, i := range requiredEntries {
+		if i == 0 {
+			continue
+		}
 		entries, err := getAvailableHVSocks(p, excludePorts, i)
 		if len(entries) < i || err != nil {
 			return false

--- a/pkg/machine/hyperv/vsock/vsock.go
+++ b/pkg/machine/hyperv/vsock/vsock.go
@@ -12,18 +12,23 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/podman/v6/pkg/machine/env"
 	"go.podman.io/podman/v6/pkg/machine/sockets"
 	"go.podman.io/podman/v6/utils"
 	"golang.org/x/sys/windows/registry"
 )
 
-var ErrVSockRegistryEntryExists = errors.New("registry entry already exists")
+var (
+	ErrVSockRegistryEntryExists = errors.New("registry entry already exists")
+	ErrHVSockPortBusy           = errors.New("hvsock port is already in use")
+)
 
 const (
 	// HvsockMachineName is the string identifier for the machine name in a registry entry
 	HvsockMachineName = "MachineName"
 	// HvsockToolName is the string identifier for the tool name in a registry entry
 	HvsockToolName = "ToolName"
+	// Deprecated: Use GetToolName() instead. Kept for backward compatibility.
 	PodmanToolName = "podman"
 	// HvsockPurpose is the string identifier for the sock purpose in a registry entry
 	HvsockPurpose = "Purpose"
@@ -190,8 +195,6 @@ func (hv *HVSockRegistryEntry) validate() error {
 }
 
 func (hv *HVSockRegistryEntry) exists() (bool, error) {
-	foo := hv.fqPath()
-	_ = foo
 	_, err := openVSockRegistryEntry(hv.fqPath())
 	if err == nil {
 		return true, nil
@@ -241,7 +244,7 @@ func NewHVSockRegistryEntry(purpose HVSockPurpose, keep bool) (*HVSockRegistryEn
 		KeyName:                PortToKeyName(port),
 		Purpose:                purpose,
 		Port:                   port,
-		ToolName:               PodmanToolName,
+		ToolName:               env.GetToolName(),
 		KeepAfterMachineRemove: keep,
 	}
 	if err := r.Add(); err != nil {
@@ -388,7 +391,7 @@ func loadHVSockRegistryEntries(purpose HVSockPurpose, limit int) ([]*HVSockRegis
 			continue
 		}
 
-		if toolName != PodmanToolName {
+		if toolName != env.GetToolName() {
 			continue
 		}
 
@@ -409,7 +412,7 @@ func loadHVSockRegistryEntries(purpose HVSockPurpose, limit int) ([]*HVSockRegis
 			KeyName:                subKeyName,
 			Purpose:                entryPurpose,
 			Port:                   port,
-			ToolName:               PodmanToolName,
+			ToolName:               toolName,
 			KeepAfterMachineRemove: keepBool,
 		})
 	}
@@ -417,7 +420,7 @@ func loadHVSockRegistryEntries(purpose HVSockPurpose, limit int) ([]*HVSockRegis
 	return allEntries, nil
 }
 
-func CheckIfHVSockRegistryEntriesExist(mountsNum int) bool {
+func CheckIfHVSockRegistryEntriesExist(mountsNum int, excludePorts map[uint64]bool) bool {
 	// The number or required HVSock registry entries
 	// depends on the purpose
 	requiredEntries := map[HVSockPurpose]int{
@@ -426,7 +429,7 @@ func CheckIfHVSockRegistryEntriesExist(mountsNum int) bool {
 		Fileserver: mountsNum,
 	}
 	for p, i := range requiredEntries {
-		entries, err := loadHVSockRegistryEntries(p, i)
+		entries, err := getAvailableHVSocks(p, excludePorts, i)
 		if len(entries) < i || err != nil {
 			return false
 		}
@@ -459,34 +462,37 @@ func parseHexToUint64(hex string) (uint64, error) {
 	return strconv.ParseUint(hex, 16, 64)
 }
 
-// It removes HVSock registry entries for Network, Events, and Fileserver.
-// It returns loading errors immediately. For removals, it attempts all, logs individual failures,
-// and returns a joined error (via errors.Join) if any occur.
-// Returns nil only if all entries are loaded and removed successfully.
-func RemoveAllHVSockRegistryEntries() error {
-	// Tear down vsocks
-	networkSocks, err := LoadAllHVSockRegistryEntriesByPurpose(Network)
-	if err != nil {
-		return err
+// RemoveAllHVSockRegistryEntries removes HVSock registry entries for Network, Events, and Fileserver.
+// When force is false, entries with KeepAfterMachineRemove=true are preserved.
+// When force is true, all entries are removed regardless of the KeepAfterMachineRemove flag.
+func RemoveAllHVSockRegistryEntries(force bool) error {
+	purposes := []HVSockPurpose{Network, Events, Fileserver}
+	var allSocks []*HVSockRegistryEntry
+	for _, p := range purposes {
+		socks, err := LoadAllHVSockRegistryEntriesByPurpose(p)
+		if err != nil {
+			return err
+		}
+		allSocks = append(allSocks, socks...)
 	}
-	eventsSocks, err := LoadAllHVSockRegistryEntriesByPurpose(Events)
-	if err != nil {
-		return err
-	}
-	fileserverSocks, err := LoadAllHVSockRegistryEntriesByPurpose(Fileserver)
-	if err != nil {
-		return err
-	}
+	return removeEntries(allSocks, force)
+}
 
-	allSocks := make([]*HVSockRegistryEntry, 0, len(networkSocks)+len(eventsSocks)+len(fileserverSocks))
-	allSocks = append(allSocks, networkSocks...)
-	allSocks = append(allSocks, eventsSocks...)
-	allSocks = append(allSocks, fileserverSocks...)
+// RemoveHVSockRegistryEntriesByPurpose removes HVSock registry entries for a specific purpose.
+// When force is false, entries with KeepAfterMachineRemove=true are preserved.
+// When force is true, all matching entries are removed.
+func RemoveHVSockRegistryEntriesByPurpose(purpose HVSockPurpose, force bool) error {
+	socks, err := LoadAllHVSockRegistryEntriesByPurpose(purpose)
+	if err != nil {
+		return err
+	}
+	return removeEntries(socks, force)
+}
 
+func removeEntries(entries []*HVSockRegistryEntry, force bool) error {
 	var removalErrors []error
-	for _, sock := range allSocks {
-		// Don't remove registry entries if KeepAfterMachineRemove is set to true
-		if sock.KeepAfterMachineRemove {
+	for _, sock := range entries {
+		if !force && sock.KeepAfterMachineRemove {
 			continue
 		}
 		if err := sock.Remove(); err != nil {
@@ -494,10 +500,72 @@ func RemoveAllHVSockRegistryEntries() error {
 			removalErrors = append(removalErrors, fmt.Errorf("failed to remove sock %s: %w", sock.KeyName, err))
 		}
 	}
-
 	if len(removalErrors) > 0 {
 		return errors.Join(removalErrors...)
 	}
-
 	return nil
+}
+
+// CheckPortAvailable verifies that the given hvsock port is not currently
+// being listened on by another process. It attempts to bind a listener and
+// immediately closes it. Returns nil if the port is free, ErrHVSockPortBusy
+// if another process is already listening.
+func CheckPortAvailable(port uint64) error {
+	addr := winio.HvsockAddr{
+		VMID:      winio.HvsockGUIDWildcard(),
+		ServiceID: winio.VsockServiceID(uint32(port)),
+	}
+	listener, err := winio.ListenHvsock(&addr)
+	if err != nil {
+		return fmt.Errorf("%w: port %d: %v", ErrHVSockPortBusy, port, err)
+	}
+	_ = listener.Close()
+	return nil
+}
+
+// ListAvailableHVSocks loads registry entries
+// for the given purpose, filters out excluded ports and ports that are currently
+// busy (listened on by another process), and returns the remaining entries.
+func ListAvailableHVSocks(purpose HVSockPurpose, excludePorts map[uint64]bool) ([]*HVSockRegistryEntry, error) {
+	entries, err := getAvailableHVSocks(purpose, excludePorts, -1)
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// GetAvailableHVSock returns the first available registry entry for the given purpose
+func GetAvailableHVSock(purpose HVSockPurpose, excludePorts map[uint64]bool) (*HVSockRegistryEntry, error) {
+	entries, err := getAvailableHVSocks(purpose, excludePorts, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no available hvsock found for purpose: %s", purpose.String())
+	}
+	return entries[0], nil
+}
+
+func getAvailableHVSocks(purpose HVSockPurpose, excludePorts map[uint64]bool, limit int) ([]*HVSockRegistryEntry, error) {
+	entries, err := loadHVSockRegistryEntries(purpose, -1)
+	if err != nil {
+		return nil, err
+	}
+	available := make([]*HVSockRegistryEntry, 0, len(entries))
+	for _, entry := range entries {
+		if excludePorts[entry.Port] {
+			logrus.Debugf("hvsock port %d (%s) is claimed by another machine, skipping", entry.Port, purpose)
+			continue
+		}
+		if err := CheckPortAvailable(entry.Port); err == nil {
+			available = append(available, entry)
+		} else {
+			logrus.Debugf("hvsock port %d (%s) is busy, skipping", entry.Port, purpose)
+		}
+
+		if limit != -1 && len(available) >= limit {
+			break
+		}
+	}
+	return available, nil
 }

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/config"
-	"go.podman.io/podman/v6/cmd/podman/registry"
 	"go.podman.io/podman/v6/pkg/machine"
 	"go.podman.io/podman/v6/pkg/machine/certificates"
 	"go.podman.io/podman/v6/pkg/machine/connection"
@@ -28,7 +27,6 @@ import (
 	"go.podman.io/podman/v6/pkg/machine/proxyenv"
 	"go.podman.io/podman/v6/pkg/machine/vmconfigs"
 	"go.podman.io/podman/v6/utils"
-	"golang.org/x/term"
 )
 
 var ErrRemoveUserCancelled = errors.New("user cancelled the removal operation")
@@ -547,10 +545,10 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 	if mc.HostUser.Rootful {
 		connName += "-root"
 	}
-	conn, err := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection(connName, false)
+	/* conn, err := registry.PodmanConfig().ContainersConfDefaultsRO.GetConnection(connName, false)
 	if err != nil {
 		return err
-	}
+	} */
 
 	// Don't check if provider supports parallel running machines
 	if mp.RequireExclusiveActive() {
@@ -578,7 +576,7 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 
 	// Do not do anything with the system connection if its already
 	// the default system connection.
-	if !conn.Default {
+	/* 	if !conn.Default {
 		if updateSystemConn != nil {
 			updateDefaultConnection = *updateSystemConn
 		} else if term.IsTerminal(int(os.Stdin.Fd())) {
@@ -599,7 +597,7 @@ func Start(mc *vmconfigs.MachineConfig, mp vmconfigs.VMProvider, opts machine.St
 			}
 			updateDefaultConnection = response
 		}
-	}
+	} */
 
 	// if the machine cannot continue starting due to a signal, ensure the state
 	// reflects the machine is no longer starting


### PR DESCRIPTION
Temp PR to experimenting with the new Podman 6 feature to prefill the Registry to run Hyperv machine as a normal user. This changes allows to manage multi VMs on macadam.